### PR TITLE
Authorisation to Authorization

### DIFF
--- a/src/en/callbacks.md
+++ b/src/en/callbacks.md
@@ -7,14 +7,14 @@ Callbacks are when GC Notify sends `POST` requests to your service. You can get 
 - a text message or email you’ve sent is delivered or fails
 - your service receives a text message
 
-You'll need to provide a bearer token, for security. We'll add this to the authorisation header of the callback request.
+You'll need to provide a bearer token, for security. We'll add this to the authorization header of the callback request.
 
 ## Set up callbacks
 
 You must provide:
 
 - a URL where Notify will post the callback to
-- a bearer token, for security, which GC Notify will put in the authorisation header of the requests
+- a bearer token, for security, which GC Notify will put in the authorization header of the requests
 
 To do this:
 
@@ -26,7 +26,7 @@ When creating a bearer token, you should:
 
 - Keep your bearer token secure
 - Change it if you have any reason to think it might no longer be trusted
-- Make sure that callbacks you receive from GC Notify contain your bearer token in the `Authorisation` header
+- Make sure that callbacks you receive from GC Notify contain your bearer token in the `Authorization` header
 - Use a hashed value so that GC Notify doesn't hold the true token
 
 ## Message delivery receipts

--- a/src/en/start.md
+++ b/src/en/start.md
@@ -7,14 +7,14 @@ https://api.notification.canada.ca
 ```
 ## Headers
 
-**Authorisation header**
+**Authorization header**
 
-The authorisation header is an [API key](keys.md). You must include an authorisation header.
+The authorization header is an [API key](keys.md). You must include an authorization header.
 
 The header consists of:
 
 ```json
-"Authorisation": "ApiKey-v1 YOUR-SECRET-KEY"
+"Authorization": "ApiKey-v1 YOUR-SECRET-KEY"
 ```
 
 That secret key forms a part of your [API key](keys.md), which follows the format `{key_name}-{iss-uuid}-{secret-key-uuid}`.
@@ -29,7 +29,7 @@ For example, if your API key is
 Therefore, you would need to set the HTTP header to the following value:
 
 ```json
-"Authorisation": "ApiKey-v1 3d844edf-8d35-48ac-975b-e847b4f122b0"
+"Authorization": "ApiKey-v1 3d844edf-8d35-48ac-975b-e847b4f122b0"
 ```
 
 Note that your secret key is the last 36 characters of your API key.


### PR DESCRIPTION
GDS uses the British spelling, let's use the US spelling. It matters for the HTTP header because if you put `Authorisation` instead of `Authorization` you will not be able to authenticate.

Anik, can you update this in French as well if you're working on these pages at the moment?