### PR TITLE
feat: add edit links on pages

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -39,6 +39,7 @@ module.exports = {
     lastUpdated: true,
     nextLinks: true,
     prevLinks: true,
+    docsRepo: 'cds-snc/notification-documentation',
     docsDir: 'src',
     docsBranch: 'main',
     smoothScroll: true,

--- a/src/en/README.md
+++ b/src/en/README.md
@@ -1,3 +1,7 @@
+---
+editLink: false
+---
+
 # Integrate the API
 
 This documentation is for developers who want to integrate the GC Notify application programming interface (API) with their department's web application or back office system.

--- a/src/fr/README.md
+++ b/src/fr/README.md
@@ -1,3 +1,7 @@
+---
+editLink: false
+---
+
 # Intégrer l'API
 
 Cette documentation s’adresse aux développeurs qui souhaitent intégrer l’interface de programmation d’application (API) de GC Notification à l’application Web ou au système administratif de leur ministère.


### PR DESCRIPTION
Add edit links in the footer pointing to the appropriate GitHub file, but disable edit links on the homepage.