### PR TITLE
Callbacks FR - tweak

### DIFF
--- a/src/fr/rappel.md
+++ b/src/fr/rappel.md
@@ -34,7 +34,7 @@ Cette fonctionnalité fonctionne avec les clés API de test, mais ne fonctionne 
 
 Le message de la fonction de rappel est formaté en JSON. Toutes les valeurs sont des chaînes de caractères. Voici la clé, la description et le format des arguments du message de la fonction de rappel :
 
-|Clé | Description | Format|
+|Chaîne de clé | Description | Format|
 |:---|:---|:---|
 |`id` | ID de GC Notification pour les accusés d’état  | UUID|
 |`reference` | Référence envoyée par le service | 12345678|

--- a/src/fr/rappel.md
+++ b/src/fr/rappel.md
@@ -34,7 +34,7 @@ Cette fonctionnalité fonctionne avec les clés API de test, mais ne fonctionne 
 
 Le message de la fonction de rappel est formaté en JSON. Toutes les valeurs sont des chaînes de caractères. Voici la clé, la description et le format des arguments du message de la fonction de rappel :
 
-|Chaîne de clé | Description | Format|
+|Clé | Description | Format de la chaîne|
 |:---|:---|:---|
 |`id` | ID de GC Notification pour les accusés d’état  | UUID|
 |`reference` | Référence envoyée par le service | 12345678|


### PR DESCRIPTION
Attempt to fix #48 

> Perhaps we can make it more clear that all the values mentioned in Callbacks > Message delivery receipts are strings? It’s possible that someone skips to the table and doesn’t read the text preceding it (Not very high priority item)