### PR TITLE
API keys FR - tweak

### DIFF
--- a/src/fr/cles.md
+++ b/src/fr/cles.md
@@ -6,7 +6,7 @@ Il existe trois types de clés API différents :
 - équipe et liste de confiance
 - en fonction
 
-Lorsque vous configurez un nouveau service, il démarrera en mode d’essai. Un service en mode d’essai peut créer des clés de test, d’équipe et de liste de confiance. Vous devez disposer d’un service activé pour créer une clé en fonction.
+Lorsque vous configurez un nouveau service, il démarrera en mode d’essai. Un service en mode d’essai peut créer des __clés de test__ ou __des clés d’équipe et de liste de confiance__. Vous devez disposer d’un service activé pour créer une __clé en fonction__.
 
 Pour créer une clé API :
 


### PR DESCRIPTION
Attempt to fix #47

> On the API keys page, the following line exists:

A service in trial mode can create test and team and safelist keys

This can be a little difficult to read. Perhaps there is a way to clearly distinguish these are 2 separate keys such as bolding? Ex. A service in trial mode can create test and team and safelist keys