### PR TITLE
API keys EN - tweak

### DIFF
--- a/src/en/keys.md
+++ b/src/en/keys.md
@@ -6,7 +6,7 @@ There are three different types of API keys:
 - team and safelist
 - live
 
-When you set up a new service it will start in trial mode. A service in trial mode can create test and team and safelist keys. You must have a live service to create a live key.
+When you set up a new service it will start in trial mode. A service in trial mode can create either __test__ or __team and safelist__ keys. You must have a live service to create a __live key__.
 
 To create an API key:
 


### PR DESCRIPTION
Attempt to fix #47 

> On the API keys page, the following line exists:

A service in trial mode can create test and team and safelist keys

This can be a little difficult to read. Perhaps there is a way to clearly distinguish these are 2 separate keys such as bolding? Ex. A service in trial mode can create test and team and safelist keys