### PR TITLE
Document new filename arg for attachments

### DIFF
--- a/src/en/send.md
+++ b/src/en/send.md
@@ -127,11 +127,12 @@ You’ll need to convert the file into a string that is base64 encoded.
 Pass the encoded string into an object with a `file` key, and put that in the personalisation argument. For example:
 
 ```json
-"personalisation":{
+"personalisation": {
   "first_name": "Amala",
   "application_date": "2018-01-01",
   "link_to_file": {
-    "file": "file as base64 encoded string"
+    "file": "file as base64 encoded string",
+    "filename": "your_custom_filename.pdf"
   }
 }
 ```
@@ -141,11 +142,12 @@ Pass the encoded string into an object with a `file` key, and put that in the pe
 Uploads for CSV files should set the `is_csv` flag as `true` to ensure it is downloaded as a .csv file. For example:
 
 ```json
-"personalisation":{
+"personalisation": {
   "first_name": "Amala",
   "application_date": "2018-01-01",
   "link_to_file": {
     "file": "CSV file as base64 encoded string",
+    "filename": "your_csv_filename.csv",
     "is_csv": true
   }
 }

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -127,11 +127,12 @@ Vous devrez convertir le fichier en chaîne codée base64.
 Passez la chaîne encodée dans un objet avec une clé `file`, et mettez-la dans l’argument de personnalisation. Par exemple :
 
 ```json
-"personalisation":{
+"personalisation": {
   "first_name": "Amala",
   "application_date": "2018-01-01",
   "link_to_file": {
-    "file": "file as base64 encoded string"
+    "file": "fichier CSV encodé dans une chaîne de caractères en base64",
+    "filename": "nom_de_votre_fichier.pdf"
   }
 }
 ```
@@ -141,11 +142,12 @@ Passez la chaîne encodée dans un objet avec une clé `file`, et mettez-la dans
 Les téléchargements pour les fichiers CSV doivent définir l’indicateur `is_csv` comme `true` pour s’assurer qu’il est téléchargé en tant que fichier .csv. Par exemple :
 
 ```json
-"personalisation":{
+"personalisation": {
   "first_name": "Amala",
   "application_date": "2018-01-01",
   "link_to_file": {
-    "file": "CSV file as base64 encoded string",
+    "file": "fichier CSV encodé dans une chaîne de caractères en base64",
+    "filename": "nom_de_votre_csv.csv",
     "is_csv": true
   }
 }


### PR DESCRIPTION
Document the new `filename` argument when posting attachments on `POST /v2/notifications/email`

Trello card: https://trello.com/c/BVIe44l5/370-let-clients-name-the-files-they-are-attaching-in-the-api.

Review app: https://cds-snc.github.io/notification-documentation/review-apps/attachments-filename-arg/d1edea/en/send.html#sending-a-file-by-email