### PR TITLE
Document sending_method argument for files

### DIFF
--- a/src/en/clients.md
+++ b/src/en/clients.md
@@ -9,6 +9,13 @@ You will need to change the API endpoint when creating a client.
 
 <Content :page-key="$site.pages.find(p => p.relativePath === 'en/_api_endpoints.md').key"/>
 
+::: warning Feature differences to keep in mind
+
+- [Sending files by email is different with GC Notify](send.md#sending-a-file-by-email)
+- Sending letters is not available
+- Receiving text messages is not available
+:::
+
 ### GOV.UK Notify clients
 
 * [Java](https://docs.notifications.service.gov.uk/java.html)
@@ -17,4 +24,6 @@ You will need to change the API endpoint when creating a client.
 * [PHP](https://docs.notifications.service.gov.uk/php.html)
 * [Python](https://docs.notifications.service.gov.uk/python.html)
 * [Ruby](https://docs.notifications.service.gov.uk/ruby.html)
+
+
 

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -97,34 +97,69 @@ You can leave out this argument if your service only has one reply-to email addr
 Sending files by email is not enabled by default. To turn on this feature, [contact us](https://notification.canada.ca/contact).
 :::
 
-To send a file by email, you'll need to add a placeholder to the template then upload a file. The placeholder will contain a secure link to download the file. 
+### File types and size requirements
+You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Microsoft Word Document files. Your file must be smaller than 10MB.
 
-The links are unique and unguessable. GC Notify cannot access or decrypt your file.
+[Contact us](https://notification.canada.ca/contact) if you need to send other file types.
+
+
+### Sending methods
+You can send files in two ways on Notify:
+
+1. directly attached to emails
+1. through a unique link to a web interface. Links are unique and unguessable.
+
+You are able to control how files are delivered to recipients on every
+API call. GC Notify cannot access or decrypt your files.
+
+::: tip Choosing the appropriate sending method
+
+People are generally more used to files directly attached to emails. With that in mind, it's not uncommon to see attachments being blocked by security rules or some email providers. Use the unique link method to prevent your attachments from being blocked.
+
+We encourage you to perform tests before choosing a sending method.
+
+:::
 
 ### Add contact details to the file download page
 
 To turn on this feature, [contact us](https://notification.canada.ca/contact).
 
-### Add a placeholder to the template
+### Add a placeholder to the template (optional)
+
+::: tip Only relevant if using unique links
+
+Adding a placeholder in your template is only needed if you’re sending files with a unique link. You do not need to add a placeholder if you’re sending files as direct attachments.
+
+:::
 
 1. [Sign in to GC Notify](https://notification.canada.ca/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
 1. Select __Edit__.
 1. Add a placeholder to the email template using double brackets. For example:
 
-"Download your file at: ((link_to_file))"
+```
+You can [now download your application](((link_to_file))).
+```
 
 ### Upload your file
 
-::: tip File types and size requirements
-You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Microsoft Word Document files. Your file must be smaller than 10MB.
+In order to send files, you need to pass a dictionary of arguments in the `personalisation` argument. Pass this dictionary to the placeholder key if it’s present in your template or use a name of your choice.
 
-[Contact us](https://notification.canada.ca/contact) if you need to send other file types.
-:::
+You’ll need to specify:
 
-You’ll need to convert the file into a string that is base64 encoded.
+- `file`: convert the file into a string that is base64 encoded. Example: `Q2FuYWRh` (`Canada` encoded in base64)
+- `filename`: the filename of the file you are sending. Example: `application.pdf`
+- `sending_method`: specify how you want to send this file. `attach` for the direct attachment method, `link` to generate a unique download link
 
-Pass the encoded string into an object with a `file` key, and put that in the personalisation argument. For example:
+For example, if you have a template with two placeholders and want to use the unique link method.
+
+```
+Hello ((first_name)),
+
+We received your application on ((application_date)).
+
+You can [now download your application](((link_to_file))).
+```
 
 ```json
 "personalisation": {
@@ -132,23 +167,30 @@ Pass the encoded string into an object with a `file` key, and put that in the pe
   "application_date": "2018-01-01",
   "link_to_file": {
     "file": "file as base64 encoded string",
-    "filename": "your_custom_filename.pdf"
+    "filename": "your_custom_filename.pdf",
+    "sending_method": "link"
   }
 }
 ```
 
-**CSV files**
+If you are using the direct attachment method:
 
-Uploads for CSV files should set the `is_csv` flag as `true` to ensure it is downloaded as a .csv file. For example:
+```
+Hello ((first_name)),
+
+We received your application on ((application_date)).
+
+You will your application attached.
+```
 
 ```json
 "personalisation": {
   "first_name": "Amala",
   "application_date": "2018-01-01",
-  "link_to_file": {
-    "file": "CSV file as base64 encoded string",
-    "filename": "your_csv_filename.csv",
-    "is_csv": true
+  "application_file": {
+    "file": "file as base64 encoded string",
+    "filename": "your_custom_filename.pdf",
+    "sending_method": "attach"
   }
 }
 ```

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -98,9 +98,7 @@ Sending files by email is an API-only feature. To turn on this feature, [contact
 :::
 
 ### File types and size requirements
-You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Microsoft Word Document files.
-
-The maximum email size including content and attachments must be smaller than 10MB. The unique link method does not factor into calculated email size.
+You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Microsoft Word Document files. Your email including the file must be smaller than 10MB.
 
 [Contact us](https://notification.canada.ca/contact) if you need to send other file types.
 
@@ -122,10 +120,6 @@ Before choosing a sending method, perform tests to see what works best for your 
 
 :::
 
-### Add contact details to the file download page
-
-To turn on this feature, [contact us](https://notification.canada.ca/contact).
-
 ### Upload your file
 
 To send files, pass a dictionary of arguments in the `personalisation` argument. Pass this dictionary to the placeholder key if it’s present in your template or use a name of your choice.
@@ -134,7 +128,7 @@ You’ll need to specify:
 
 - `file`: convert the file into a string that is base64 encoded. Example: `Q2FuYWRh` (`Canada` encoded in base64)
 - `filename`: the filename of the file you are sending. Example: `service_name_applicant_name.pdf`
-- `sending_method`: specify how you want to send this file. `attach` for the direct attachment method, `link` to generate a unique link
+- `sending_method`: specify how you want to send this file. Either `attach` for the direct attachment method or `link` to generate a unique link
 
 #### If you’re sending files as direct attachments
 

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -168,8 +168,10 @@ You will find your application attached.
 1. [Sign in to GC Notify](https://notification.canada.ca/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
 1. Select __Edit__.
-1. Add a placeholder to the email template using double brackets. For example: `((link to file))`
+1. Add a placeholder to the email template using double brackets. For example: `((link_to_file))`
 
+```
+You can [now download your application](((link_to_file))).
 ```
 
 For example:

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -94,20 +94,22 @@ You can leave out this argument if your service only has one reply-to email addr
 
 ::: warning Enabling this feature
 
-Sending files by email is not enabled by default. To turn on this feature, [contact us](https://notification.canada.ca/contact).
+Sending files by email is an API-only feature. To turn on this feature, [contact us](https://notification.canada.ca/contact).
 :::
 
 ### File types and size requirements
-You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Microsoft Word Document files. Your file must be smaller than 10MB.
+You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Microsoft Word Document files.
+
+The maximum email size including content and attachments must be smaller than 10MB. The unique link method does not factor into calculated email size.
 
 [Contact us](https://notification.canada.ca/contact) if you need to send other file types.
 
-
 ### Sending methods
+
 You can send files in two ways on GC Notify:
 
 1. directly attached to emails
-1. through a private link to a web interface
+1. through a unique link to a web interface
 
 You are able to control how files are delivered to recipients on every
 API call. GC Notify cannot access or decrypt your files.
@@ -124,13 +126,50 @@ Before choosing a sending method, perform tests to see what works best for your 
 
 To turn on this feature, [contact us](https://notification.canada.ca/contact).
 
-### Add a placeholder to the template (optional)
+### Upload your file
 
-::: tip Only relevant if using unique links
+To send files, pass a dictionary of arguments in the `personalisation` argument. Pass this dictionary to the placeholder key if it’s present in your template or use a name of your choice.
 
-Adding a placeholder in your template is only needed if you’re sending files with a unique link. You do not need to add a placeholder if you’re sending files as direct attachments.
+You’ll need to specify:
 
-:::
+- `file`: convert the file into a string that is base64 encoded. Example: `Q2FuYWRh` (`Canada` encoded in base64)
+- `filename`: the filename of the file you are sending. Example: `service_name_applicant_name.pdf`
+- `sending_method`: specify how you want to send this file. `attach` for the direct attachment method, `link` to generate a unique link
+
+#### If you’re sending files as direct attachments
+
+Specify `attach` as `sending_method`.
+
+For example:
+
+**Template**
+```
+Hello ((first_name)),
+
+We received your application on ((application_date)).
+
+You will find your application attached.
+```
+
+**HTTP parameters**
+```json
+"personalisation": {
+  "first_name": "Amala",
+  "application_date": "2018-01-01",
+  "application_file": {
+    "file": "file as base64 encoded string",
+    "filename": "your_custom_filename.pdf",
+    "sending_method": "attach"
+  }
+}
+```
+
+#### If you’re sending files with unique links
+
+1. Add a placeholder to the email template
+1. Send HTTP requests, specify `link` as `sending_method`
+
+**Add a placeholder to the template**
 
 1. [Sign in to GC Notify](https://notification.canada.ca/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
@@ -141,18 +180,9 @@ Adding a placeholder in your template is only needed if you’re sending files w
 You can [now download your application](((link_to_file))).
 ```
 
-### Upload your file
+For example:
 
-To send files, pass a dictionary of arguments in the `personalisation` argument. Pass this dictionary to the placeholder key if it’s present in your template or use a name of your choice.
-
-You’ll need to specify:
-
-- `file`: convert the file into a string that is base64 encoded. Example: `Q2FuYWRh` (`Canada` encoded in base64)
-- `filename`: the filename of the file you are sending. Example: `application.pdf`
-- `sending_method`: specify how you want to send this file. `attach` for the direct attachment method, `link` to generate a unique download link
-
-For example, if you have a template with two placeholders and want to use the unique link method.
-
+**Template**
 ```
 Hello ((first_name)),
 
@@ -161,6 +191,7 @@ We received your application on ((application_date)).
 You can [now download your application](((link_to_file))).
 ```
 
+**HTTP parameters**
 ```json
 "personalisation": {
   "first_name": "Amala",
@@ -169,28 +200,6 @@ You can [now download your application](((link_to_file))).
     "file": "file as base64 encoded string",
     "filename": "your_custom_filename.pdf",
     "sending_method": "link"
-  }
-}
-```
-
-If you are using the direct attachment method:
-
-```
-Hello ((first_name)),
-
-We received your application on ((application_date)).
-
-You will find your application attached.
-```
-
-```json
-"personalisation": {
-  "first_name": "Amala",
-  "application_date": "2018-01-01",
-  "application_file": {
-    "file": "file as base64 encoded string",
-    "filename": "your_custom_filename.pdf",
-    "sending_method": "attach"
   }
 }
 ```

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -114,7 +114,7 @@ API call. GC Notify cannot access or decrypt your files.
 
 ::: tip Choosing a sending method
 
-People generally expect files to be directly attached to emails. With that in mind, it’s not uncommon to see attachments being blocked by security rules or email providers. Use the unique link method to prevent your attachments from being blocked.
+People generally expect files to be directly attached to emails. With that in mind, it’s not uncommon to see attachments being blocked by security rules or email providers. Use the unique link method to prevent your attachments from being blocked. Linked files will expire 1 year after the message has been sent.
 
 Before choosing a sending method, perform tests to see what works best for your use case.
 

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -114,7 +114,7 @@ API call. GC Notify cannot access or decrypt your files.
 
 ::: tip Choosing a sending method
 
-People generally expect files to be directly attached to emails. With that in mind, it's not uncommon to see attachments being blocked by security rules or email providers. Use the unique link method to prevent your attachments from being blocked.
+People generally expect files to be directly attached to emails. With that in mind, it’s not uncommon to see attachments being blocked by security rules or email providers. Use the unique link method to prevent your attachments from being blocked.
 
 Before choosing a sending method, perform tests to see what works best for your use case.
 
@@ -228,9 +228,15 @@ If the request is not successful, the response body is `json`, refer to the tabl
 |:---|:---|:---|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient using a team-only API key"`<br>`}]`|Use the correct type of [API key](keys.md)|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode`<br>`}]`|Your service cannot send this notification in trial mode. You can request to go live in settings.|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported file type '(FILE TYPE)'. Supported types are: '(ALLOWED TYPES)"`<br>`}]`|Wrong file type. You can only upload .pdf, .csv, .txt, .jpeg, .png, .doc, .docx, .xls, .xlsx, .rtf ou .odt files|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported file type '(FILE TYPE)'. Supported types are: '(ALLOWED TYPES)"`<br>`}]`|Wrong file type. You can only upload .pdf, .csv, .txt, .jpeg, .png, .doc, .docx, .xls, .xlsx, .rtf or .odt files|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "File did not pass the virus scan"`<br>`}]`|The file contains a virus|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Send files by email has not been set up - add contact details for your service"`<br>`}]`|See how to add contact details to the file download page|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "sending_method is a required property"`<br>`}]`|See [how to send files by email](#sending-a-file-by-email)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is a required property"`<br>`}]`|See [how to send files by email](#sending-a-file-by-email)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation (key) is not one of [attach, link]"`<br>`}]`|See [how to send files by email](#sending-a-file-by-email)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "(key) : Incorrect padding : Error decoding base64 field"`<br>`}]`|See [how to send files by email](#sending-a-file-by-email)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too short"`<br>`}]`|See [how to send files by email](#sending-a-file-by-email)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too long"`<br>`}]`|See [how to send files by email](#sending-a-file-by-email)|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct [API keys](keys.md)|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 1000 requests per 60 seconds"`<br>`}]`|Refer to [API rate limits](limits.md#rate-limits) for more information|

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -100,7 +100,7 @@ Sending files by email is an API-only feature. To turn on this feature, [contact
 ### File types and size requirements
 You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Microsoft Word Document files. Your email including the file must be smaller than 10MB.
 
-[Contact us](https://notification.canada.ca/contact) if you need to send other file types.
+If you need to send other file types, [contact us](https://notification.canada.ca/contact).
 
 ### Sending methods
 
@@ -231,12 +231,12 @@ If the request is not successful, the response body is `json`, refer to the tabl
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported file type '(FILE TYPE)'. Supported types are: '(ALLOWED TYPES)"`<br>`}]`|Wrong file type. You can only upload .pdf, .csv, .txt, .jpeg, .png, .doc, .docx, .xls, .xlsx, .rtf or .odt files|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "File did not pass the virus scan"`<br>`}]`|The file contains a virus|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Send files by email has not been set up - add contact details for your service"`<br>`}]`|See how to add contact details to the file download page|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "sending_method is a required property"`<br>`}]`|See [how to send files by email](#sending-a-file-by-email)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is a required property"`<br>`}]`|See [how to send files by email](#sending-a-file-by-email)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation (key) is not one of [attach, link]"`<br>`}]`|See [how to send files by email](#sending-a-file-by-email)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "(key) : Incorrect padding : Error decoding base64 field"`<br>`}]`|See [how to send files by email](#sending-a-file-by-email)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too short"`<br>`}]`|See [how to send files by email](#sending-a-file-by-email)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too long"`<br>`}]`|See [how to send files by email](#sending-a-file-by-email)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "sending_method is a required property"`<br>`}]`|Specify either `attach` or `link` as a sending method|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is a required property"`<br>`}]`|Specify a filename for the file you are sending|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation (key) is not one of [attach, link]"`<br>`}]`|The sending method specified must be either `attach` or `link`|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "(key) : Incorrect padding : Error decoding base64 field"`<br>`}]`|The file must be converted to a string that is base64 encoded|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too short"`<br>`}]`|File name must be at least 3 characters|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too long"`<br>`}]`|File name must be less than 250 characters|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Check your system clock|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Use the correct [API keys](keys.md)|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 1000 requests per 60 seconds"`<br>`}]`|Refer to [API rate limits](limits.md#rate-limits) for more information|

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -104,19 +104,19 @@ You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Mic
 
 
 ### Sending methods
-You can send files in two ways on Notify:
+You can send files in two ways on GC Notify:
 
 1. directly attached to emails
-1. through a unique link to a web interface. Links are unique and unguessable.
+1. through a private link to a web interface
 
 You are able to control how files are delivered to recipients on every
 API call. GC Notify cannot access or decrypt your files.
 
-::: tip Choosing the appropriate sending method
+::: tip Choosing a sending method
 
-People are generally more used to files directly attached to emails. With that in mind, it's not uncommon to see attachments being blocked by security rules or some email providers. Use the unique link method to prevent your attachments from being blocked.
+People generally expect files to be directly attached to emails. With that in mind, it's not uncommon to see attachments being blocked by security rules or email providers. Use the unique link method to prevent your attachments from being blocked.
 
-We encourage you to perform tests before choosing a sending method.
+Before choosing a sending method, perform tests to see what works best for your use case.
 
 :::
 
@@ -143,7 +143,7 @@ You can [now download your application](((link_to_file))).
 
 ### Upload your file
 
-In order to send files, you need to pass a dictionary of arguments in the `personalisation` argument. Pass this dictionary to the placeholder key if it’s present in your template or use a name of your choice.
+To send files, pass a dictionary of arguments in the `personalisation` argument. Pass this dictionary to the placeholder key if it’s present in your template or use a name of your choice.
 
 You’ll need to specify:
 

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -122,7 +122,7 @@ Before choosing a sending method, perform tests to see what works best for your 
 
 ### Upload your file
 
-To send files, pass a dictionary of arguments in the `personalisation` argument. Pass this dictionary to the placeholder key if it’s present in your template or use a name of your choice.
+To send files, pass a dictionary in the `personalisation` argument. Pass this dictionary to the placeholder key if it’s present in your template or use a name of your choice.
 
 You’ll need to specify:
 
@@ -168,10 +168,8 @@ You will find your application attached.
 1. [Sign in to GC Notify](https://notification.canada.ca/sign-in).
 1. Go to the __Templates__ page and select the relevant email template.
 1. Select __Edit__.
-1. Add a placeholder to the email template using double brackets. For example:
+1. Add a placeholder to the email template using double brackets. For example: `((link to file))`
 
-```
-You can [now download your application](((link_to_file))).
 ```
 
 For example:

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -180,7 +180,7 @@ Hello ((first_name)),
 
 We received your application on ((application_date)).
 
-You will your application attached.
+You will find your application attached.
 ```
 
 ```json

--- a/src/fr/clients.md
+++ b/src/fr/clients.md
@@ -8,6 +8,13 @@ Vous devrez modifier votre point de terminaison :
 
 <Content :page-key="$site.pages.find(p => p.relativePath === 'en/_api_endpoints.md').key"/>
 
+::: warning Différences de fonctionnalités à considérer
+
+- [L'envoi de fichiers par courriel est différent avec GC Notification](envoyer.md#envoyer-un-fichier-par-courriel)
+- L'envoi de lettres n'est pas disponible
+- La réception de messages texte n'est pas disponible
+:::
+
 ## Clients de GOV.UK
 
 * [Java](https://docs.notifications.service.gov.uk/java.html) (disponible en anglais seulement)

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -166,11 +166,8 @@ Vous trouverez votre demande en pièce jointe.
 1. [Connectez-vous à GC Notification](https://notification.canada.ca/sign-in?lang=fr).
 1. Accédez à la page __Gabarits__ et sélectionnez le gabarit de courriel approprié.
 1. Sélectionnez __Modifier__.
-1. Ajoutez un espace réservé au gabarit de courriel à l’aide de parenthèses doubles. Par exemple :
+1. Ajoutez un espace réservé au gabarit de courriel à l’aide de parenthèses doubles. Par exemple : `((lien_vers_fichier))`
 
-```
-Vous pouvez télécharger [votre document](((lien_vers_fichier))).
-```
 
 Par exemple :
 

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -228,13 +228,13 @@ Si la demande a été refusée, le corps de la réponse est “json”, consulte
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode`<br>`}]`|Votre service ne peut pas envoyer cette notification en mode d’essai. Activez votre service dans les paramètres.|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported file type '(FILE TYPE)'. Supported types are: '(ALLOWED TYPES)"`<br>`}]`|Mauvais type de fichier. Vous ne pouvez télécharger que des fichiers .pdf, .csv, .txt, .jpeg, .png, .doc, .docx, .xls, .xlsx, .rtf ou .odt|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "File did not pass the virus scan"`<br>`}]`|Le fichier contient un virus|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Send files by email has not been set up - add contact details for your service"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel) |
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "sending_method is a required property"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is a required property"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation (key) is not one of [attach, link]"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "(key) : Incorrect padding : Error decoding base64 field"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too short"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too long"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Send files by email has not been set up - add contact details for your service"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel) |
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "sending_method is a required property"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is a required property"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation (key) is not one of [attach, link]"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "(key) : Incorrect padding : Error decoding base64 field"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too short"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too long"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Vérifiez votre horloge système|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Utilisez la bonne [clé API](cles.md)|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 1000 requests per 60 seconds"`<br>`}]`|Reportez-vous à [Débits maximaux API](limites.md) pour plus de renseignements|

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -112,7 +112,7 @@ Il est possible de téléverser des fichiers de deux manières sur GC Notificati
 
 ::: tip Choisir une méthode d’envoi
 
-Il est plus commun de recevoir des pièces jointes plutôt que des liens uniques. Toutefois, il n’est pas rare que des pièces jointes soient bloquées par des règles de sécurité ou par certains fournisseurs de comptes de courriel. Utilisez la méthode d’envoi de lien unique pour éviter que vos pièces jointes soient bloquées.
+Il est plus commun de recevoir des pièces jointes plutôt que des liens uniques. Toutefois, il n’est pas rare que des pièces jointes soient bloquées par des règles de sécurité ou par certains fournisseurs de comptes de courriel. Utilisez la méthode d’envoi de lien unique pour éviter que vos pièces jointes soient bloquées. Les fichiers envoyés par le biais d’un lien unique seront supprimés un an après l’envoi du message.
 
 Avant de choisir une méthode d’envoi, effectuez des tests pour vérifier la méthode la plus propice pour vous.
 
@@ -230,7 +230,7 @@ Si la demande a été refusée, le corps de la réponse est “json”, consulte
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "File did not pass the virus scan"`<br>`}]`|Le fichier contient un virus|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Send files by email has not been set up - add contact details for your service"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel) |
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "sending_method is a required property"`<br>`}]`|Indiquer soit `attach` pour une pièce jointe ou `link` pour un lien unique comme méthode d'envoi|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is a required property"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is a required property"`<br>`}]`|Précisez le nom du fichier que vous envoyez|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation (key) is not one of [attach, link]"`<br>`}]`|La méthode d'envoi précisée doit être soit `attach` pour une pièce jointe ou `link` pour un lien unique|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "(key) : Incorrect padding : Error decoding base64 field"`<br>`}]`|Le fichier doit être converti en une chaîne de caractères encodée en base64|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too short"`<br>`}]`|Le nom du fichier doit comporter au moins 3 caractères|

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -100,7 +100,7 @@ Cette fonctionnalité n’est disponible que par le biais de l’API. Pour activ
 ### Types de fichiers et prérequis de taille
 Vous pouvez téléverser des fichiers PDF, CSV, .jpeg, .png, .odt, .txt, .rtf, et des fichiers Microsoft Excel et Microsoft Word. La taille de votre fichier et de votre courriel doit être inférieure à 10 Mo.
 
-[Communiquez avec nous](https://notification.canada.ca/contact?lang=fr) si vous devez envoyer d’autres types de fichiers.
+Si vous devez envoyer d’autres types de fichiers, [communiquez avec nous](https://notification.canada.ca/contact?lang=fr) .
 
 ### Méthodes d’envoi
 
@@ -229,12 +229,12 @@ Si la demande a été refusée, le corps de la réponse est “json”, consulte
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported file type '(FILE TYPE)'. Supported types are: '(ALLOWED TYPES)"`<br>`}]`|Mauvais type de fichier. Vous ne pouvez télécharger que des fichiers .pdf, .csv, .txt, .jpeg, .png, .doc, .docx, .xls, .xlsx, .rtf ou .odt|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "File did not pass the virus scan"`<br>`}]`|Le fichier contient un virus|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Send files by email has not been set up - add contact details for your service"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel) |
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "sending_method is a required property"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "sending_method is a required property"`<br>`}]`|Indiquer soit `attach` pour une pièce jointe ou `link` pour un lien unique comme méthode d'envoi|
 |`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is a required property"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation (key) is not one of [attach, link]"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "(key) : Incorrect padding : Error decoding base64 field"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too short"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
-|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too long"`<br>`}]`|Voir [comment envoyer un fichier par courriel](#envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation (key) is not one of [attach, link]"`<br>`}]`|La méthode d'envoi précisée doit être soit `attach` pour une pièce jointe ou `link` pour un lien unique|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "(key) : Incorrect padding : Error decoding base64 field"`<br>`}]`|Le fichier doit être converti en une chaîne de caractères encodée en base64|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too short"`<br>`}]`|Le nom du fichier doit comporter au moins 3 caractères|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too long"`<br>`}]`|Le nom du fichier doit comporter moins de 250 caractères|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Vérifiez votre horloge système|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Utilisez la bonne [clé API](cles.md)|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 1000 requests per 60 seconds"`<br>`}]`|Reportez-vous à [Débits maximaux API](limites.md) pour plus de renseignements|

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -168,6 +168,9 @@ Vous trouverez votre demande en pièce jointe.
 1. Sélectionnez __Modifier__.
 1. Ajoutez un espace réservé au gabarit de courriel à l’aide de parenthèses doubles. Par exemple : `((lien_vers_fichier))`
 
+```
+Vous pouvez télécharger [votre document](((lien_vers_fichier))).
+```
 
 Par exemple :
 

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -94,61 +94,104 @@ Vous pouvez ignorer cet argument si votre service n’a qu’une seule adresse d
 
 ::: warning Activer cette fonctionnalité
 
-Cette fonctionnalité n’est pas activée par défaut. Pour activer cette fonctionnalité, [communiquez avec nous](https://notification.canada.ca/contact?lang=fr).
+Cette fonctionnalité n’est disponible que par le biais de l’API. Pour activer cette fonctionnalité, [communiquez avec nous](https://notification.canada.ca/contact?lang=fr).
 :::
 
-Pour envoyer un fichier par courriel, vous aurez à ajouter un espace réservé au gabarit, puis téléverser un fichier. L’espace réservé contient un lien sécurisé pour téléverser le fichier.
+### Types de fichiers et prérequis de taille
+Vous pouvez téléverser des fichiers PDF, CSV, .jpeg, .png, .odt, .txt, .rtf, et des fichiers Microsoft Excel et Microsoft Word. La taille de votre fichier et de votre courriel doit être inférieure à 10 Mo.
 
-Les liens sont uniques et impossibles à deviner. GC Notification ne peut pas accéder votre fichier ou le déchiffrer.
+[Communiquez avec nous](https://notification.canada.ca/contact?lang=fr) si vous devez envoyer d’autres types de fichiers.
 
-### Ajouter les coordonnées à la page de téléchargement du fichier
+### Méthodes d’envoi
 
-Pour activer cette fonctionnalité, [communiquez avec nous](https://notification.canada.ca/contact?lang=fr).
+Il est possible de téléverser des fichiers de deux manières sur GC Notification :
 
-### Ajouter un espace réservé au gabarit
+1. en tant que pièce jointe
+1. en tant que lien unique vers une interface web
+
+
+::: tip Choisir une méthode d’envoi
+
+Il est plus commun de recevoir des pièces jointes plutôt que des liens uniques. Toutefois, il n’est pas rare que des pièces jointes soient bloquées par des règles de sécurité ou par certains fournisseurs de comptes de courriel. Utilisez la méthode d’envoi de lien unique pour éviter que vos pièces jointes soient bloquées.
+
+Avant de choisir une méthode d’envoi, effectuez des tests pour vérifier la méthode la plus propice pour vous.
+
+:::
+
+### Téléverser votre fichier
+
+Pour téléverser des fichiers, passez un dictionnaire de paramètres dans la clé `personalisation`. Renseignez ce paramètre dans la clé associée à votre champ réservé dans votre gabarit, ou utilisez un nom de votre choix.
+
+Vous devrez renseigner :
+
+- `file` : convertissez votre fichier en chaîne de caractères encodée en base64. Exemple : `Q2FuYWRh` (`Canada` encodé en base64)
+- `filename` : le nom de votre fichier que vous envoyez. Exemple : `nom_service_nom_personne.pdf`
+- `sending_method` : la méthode d’envoi pour ce fichier. Indiquez soit `attach` pour la méthode d’envoi par pièce jointe ou `link` pour la méthode d’envoi par lien unique
+
+#### Si vous envoyez des fichiers en tant que pièce jointe
+
+Spécifiez `attach` en tant que `sending_method`.
+
+Par exemple :
+
+**Gabarit**
+```
+Bonjour ((nom)),
+
+Nous avons reçu vos document le ((date)).
+
+Vous trouverez votre demande en pièce jointe.
+```
+
+**Paramètres HTTP**
+```json
+"personalisation": {
+  "nom": "Amala",
+  "date": "2018-01-01",
+  "fichier": {
+    "file": "fichier encodé en base64",
+    "filename": "votre_nom_de_fichier.pdf",
+    "sending_method": "attach"
+  }
+}
+```
+
+#### Si vous envoyez des fichiers en tant que liens uniques
+
+1. Ajouter un espace réservé dans votre gabarit
+1. Envoyez des requêtes HTTP, spécifiez `link` en tant que `sending_method`
+
+**Ajouter un espace réservé au gabarit**
 
 1. [Connectez-vous à GC Notification](https://notification.canada.ca/sign-in?lang=fr).
 1. Accédez à la page __Gabarits__ et sélectionnez le gabarit de courriel approprié.
 1. Sélectionnez __Modifier__.
 1. Ajoutez un espace réservé au gabarit de courriel à l’aide de parenthèses doubles. Par exemple :
 
-"Téléchargez votre fichier à : ((link_to_file))"
-
-### Téléverser votre fichier
-
-::: tip Types de fichiers et prérequis de taille
-Vous pouvez téléverser des fichiers PDF, CSV, .jpeg, .png, .odt, .txt, .rtf, et des fichiers Microsoft Excel et Microsoft Word. La taille de votre fichier doit être inférieure à 10 Mo.
-
-[Communiquez avec nous](https://notification.canada.ca/contact?lang=fr) si vous devez envoyer d’autres types de fichiers.
-:::
-
-Vous devrez convertir le fichier en chaîne codée base64.
-
-Passez la chaîne encodée dans un objet avec une clé `file`, et mettez-la dans l’argument de personnalisation. Par exemple :
-
-```json
-"personalisation": {
-  "first_name": "Amala",
-  "application_date": "2018-01-01",
-  "link_to_file": {
-    "file": "fichier CSV encodé dans une chaîne de caractères en base64",
-    "filename": "nom_de_votre_fichier.pdf"
-  }
-}
+```
+Vous pouvez télécharger [votre document](((lien_vers_fichier))).
 ```
 
-**Fichiers CSV**
+Par exemple :
 
-Les téléchargements pour les fichiers CSV doivent définir l’indicateur `is_csv` comme `true` pour s’assurer qu’il est téléchargé en tant que fichier .csv. Par exemple :
+**Gabarit**
+```
+Bonjour ((nom)),
 
+Nous avons reçu vos document le ((date)).
+
+Vous pouvez télécharger [votre document](((lien_vers_fichier))).
+```
+
+**Paramètres HTTP**
 ```json
 "personalisation": {
-  "first_name": "Amala",
-  "application_date": "2018-01-01",
-  "link_to_file": {
-    "file": "fichier CSV encodé dans une chaîne de caractères en base64",
-    "filename": "nom_de_votre_csv.csv",
-    "is_csv": true
+  "nom": "Amala",
+  "date": "2018-01-01",
+  "lien_vers_fichier": {
+    "file": "fichier encodé en base64",
+    "filename": "votre_nom_de_fichier.pdf",
+    "sending_method": "link"
   }
 }
 ```
@@ -185,7 +228,13 @@ Si la demande a été refusée, le corps de la réponse est “json”, consulte
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Can't send to this recipient when service is in trial mode`<br>`}]`|Votre service ne peut pas envoyer cette notification en mode d’essai. Activez votre service dans les paramètres.|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Unsupported file type '(FILE TYPE)'. Supported types are: '(ALLOWED TYPES)"`<br>`}]`|Mauvais type de fichier. Vous ne pouvez télécharger que des fichiers .pdf, .csv, .txt, .jpeg, .png, .doc, .docx, .xls, .xlsx, .rtf ou .odt|
 |`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "File did not pass the virus scan"`<br>`}]`|Le fichier contient un virus|
-|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Send files by email has not been set up - add contact details for your service"`<br>`}]`|Voir comment ajouter les coordonnées à la page de téléchargement de fichier|
+|`400`|`[{`<br>`"error": "BadRequestError",`<br>`"message": "Send files by email has not been set up - add contact details for your service"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel) |
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "sending_method is a required property"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is a required property"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "personalisation (key) is not one of [attach, link]"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "(key) : Incorrect padding : Error decoding base64 field"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too short"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel)|
+|`400`|`[{`<br>`"error": "ValidationError",`<br>`"message": "filename is too long"`<br>`}]`|Voir [comment envoyer un fichier par courriel](##envoyer-un-fichier-par-courriel)|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Error: Your system clock must be accurate to within 30 seconds"`<br>`}]`|Vérifiez votre horloge système|
 |`403`|`[{`<br>`"error": "AuthError",`<br>`"message": "Invalid token: API key not found"`<br>`}]`|Utilisez la bonne [clé API](cles.md)|
 |`429`|`[{`<br>`"error": "RateLimitError",`<br>`"message": "Exceeded rate limit for key type TEAM/TEST/LIVE of 1000 requests per 60 seconds"`<br>`}]`|Reportez-vous à [Débits maximaux API](limites.md) pour plus de renseignements|


### PR DESCRIPTION
Document the new `sending_method` argument when sending files.

⚠️ Only did the English version to make sure we are on the same page. Will do the French version after.

Related to https://github.com/cds-snc/notification-api/pull/1254 https://github.com/cds-snc/notification-document-download-api/pull/32

Trello: https://trello.com/b/y1mE9CZI/gc-notify-sprint-backlog

---

Review app: https://cds-snc.github.io/notification-documentation/review-apps/document-sending-method/6b04da/en/send.html#sending-a-file-by-email