### PR TITLE
Remove mention of interface for files sent as link

### DIFF
--- a/src/en/send.md
+++ b/src/en/send.md
@@ -107,7 +107,7 @@ If you need to send other file types, [contact us](https://notification.canada.c
 You can send files in two ways on GC Notify:
 
 1. directly attached to emails
-1. through a unique link to a web interface
+1. with a unique link to download from the email
 
 You are able to control how files are delivered to recipients on every
 API call. GC Notify cannot access or decrypt your files.
@@ -158,7 +158,7 @@ You will find your application attached.
 }
 ```
 
-#### If you’re sending files with unique links
+#### If you’re sending files as unique links
 
 1. Add a placeholder to the email template
 1. Send HTTP requests, specify `link` as `sending_method`

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -106,7 +106,7 @@ If you need to send other file types, [contact us](https://notification.canada.c
 
 You can send files in two ways on GC Notify:
 
-1. directly attached to emails
+1. directly attached to the email
 1. with a unique link to download from the email
 
 You are able to control how files are delivered to recipients on every

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -106,8 +106,8 @@ Si vous devez envoyer d’autres types de fichiers, [communiquez avec nous](http
 
 Il est possible de téléverser des fichiers de deux manières sur GC Notification :
 
-1. en tant que pièce jointe
-1. en tant que lien unique vers une interface web
+1. en tant que pièce jointe au courriel
+1. en tant que lien unique pour télécharger du courriel
 
 
 ::: tip Choisir une méthode d’envoi
@@ -128,7 +128,7 @@ Vous devrez renseigner :
 - `filename` : le nom de votre fichier que vous envoyez. Exemple : `nom_service_nom_personne.pdf`
 - `sending_method` : la méthode d’envoi pour ce fichier. Indiquez soit `attach` pour la méthode d’envoi par pièce jointe ou `link` pour la méthode d’envoi par lien unique
 
-#### Si vous envoyez des fichiers en tant que pièce jointe
+#### Si vous envoyez des fichiers en tant que pièces jointes
 
 Spécifiez `attach` en tant que `sending_method`.
 


### PR DESCRIPTION
Removing all mentions of the file download interface in API documentation since we will redirect to a download link instead for now.