### PR TITLE
Respect the user custom font-size configuration

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -18,3 +18,17 @@ tr
 .custom-block.warning
   .custom-block-title
     color darken(#ffe564, 70%)
+
+/**
+ * For accessibility reason and respecting user's custom font size 
+ * configuration, the font-size properties are unset from vuepress
+ * defaults set at a hardcoded value of 16px. 
+ *
+ * Hence, visually impaired users with custom font sizes will see 
+ * the website proper to their browser's custom configuration.
+ */
+body
+    font-size: unset
+
+.sidebar
+    font-size: unset


### PR DESCRIPTION
# Summary | Résumé

Because the the default size is explicitly overridden and set to 16 px, this overrides custom browser's configuration that visually impaired users could benefit from.

The user can still zoom in and see bigger fonts, but this can lead to less predictable design, e.g. the website layout being twisted as the left side navigation takes upon the space that is meant for the content (from the zooming actions). See attached screenshots for differences between the explicit `font-size` override we have at the moment vs honouring the configuration that these changes bring in.

Based on the accessibility article by Kathleen McMahon:
https://www.24a11y.com/2019/pixels-vs-relative-units-in-css-why-its-still-a-big-deal/

# Screenshots

## Overridden font-size (current code)

The user has a custom font-size but the website enforces its font-size with no scalable metric (via `px` instead of `rem`). Hence the font size isn't any bigger despite user's custom configuration.

**Configuration:**

User's `font-size: 24px`
Website `font-size: 16px`

![image](https://user-images.githubusercontent.com/805567/114230299-ff9a6100-9946-11eb-823c-45f6808853f3.png)

## Overridden font-size with **zoom-in** (current code)

The user has a custom font-size but the website enforces its font-size with no scalable metric (via `px` instead of `rem`). Hence the user zoom in to get a bigger font size.

**Configuration:**

User's `font-size: 24px`
Website `font-size: 16px`

![image](https://user-images.githubusercontent.com/805567/114230755-89e2c500-9947-11eb-98d4-1d5f8d6c90b4.png)

## Honouring user's custom font-size (proposed changes)

The user has a custom font-size and the website honours it. No need to zoom in and the overall layout looks better as well between the side menu and content section.

**Configuration:**

User's `font-size: 24px`
Website `font-size: unset`

![image](https://user-images.githubusercontent.com/805567/114231009-dd551300-9947-11eb-8333-2b46c736a7c6.png)

# Test instructions | Instructions pour tester la modification

If you use Chrome, [go to the settings page](chrome://settings), search for the `Font size` configuration and change it to your likings.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
