### PR TITLE
feat: add new provider response field

### DIFF
--- a/src/en/callbacks.md
+++ b/src/en/callbacks.md
@@ -40,7 +40,7 @@ The callback message is formatted in JSON. All of the values are strings. The ke
 |`reference` | The reference sent by the service | 12345678|
 |`to` | The email address or phone number of the recipient | hello@canada.ca or 01234567890|
 |`status` | The status of the notification | `delivered`, `permanent-failure`, `temporary-failure` or `technical-failure`|
-|`provider_response` | The detailed response from the provider. This will only be not null in a case of a technical failure | `Blocked as spam by phone carrier`|
+|`provider_response` | The detailed response from the provider. This will only be not null in a case of a technical failure | `Blocked as spam by phone carrier` (or any other message) or nil|
 |`created_at` | The time the service sent the request | `2017-05-14T12:15:30.000000Z`|
 |`completed_at` | The last time the status was updated | `2017-05-14T12:15:30.000000Z` or nil|
 |`sent_at` | The time the notification was sent | `2017-05-14T12:15:30.000000Z` or nil|

--- a/src/en/callbacks.md
+++ b/src/en/callbacks.md
@@ -40,6 +40,7 @@ The callback message is formatted in JSON. All of the values are strings. The ke
 |`reference` | The reference sent by the service | 12345678|
 |`to` | The email address or phone number of the recipient | hello@canada.ca or 01234567890|
 |`status` | The status of the notification | `delivered`, `permanent-failure`, `temporary-failure` or `technical-failure`|
+|`provider_response` | The detailed response from the provider. This will only be not null in a case of a technical failure | `Blocked as spam by phone carrier`|
 |`created_at` | The time the service sent the request | `2017-05-14T12:15:30.000000Z`|
 |`completed_at` | The last time the status was updated | `2017-05-14T12:15:30.000000Z` or nil|
 |`sent_at` | The time the notification was sent | `2017-05-14T12:15:30.000000Z` or nil|

--- a/src/en/status.md
+++ b/src/en/status.md
@@ -61,6 +61,7 @@ If the request is successful, the response body is `json` and the status code is
   "phone_number": "+447900900123",  # required string for text messages
   "type": "email / sms", # required string
   "status": "sending / delivered / permanent-failure / temporary-failure / technical-failure", # required string
+  "provider_response": "STRING", # optional string - will not be null only when the status is a technical failure
   "template": {
     "Version": 1
     "id": "f33517ff-2a88-4f6e-b855-c550268ce08a" # required string - template ID
@@ -166,6 +167,7 @@ If the request is successful, the response body is `json` and the status code is
       "phone_number": "+447900900123",  # required string for text messages
       "type": "email / sms", # required string
       "status": "sending / delivered / permanent-failure / temporary-failure / technical-failure", # required string
+      "provider_response": "STRING", # optional string - will not be null only when the status is a technical failure
       "template": {
         "version": 1
         "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a' # required string - template ID

--- a/src/fr/etat.md
+++ b/src/fr/etat.md
@@ -61,6 +61,7 @@ Si la demande est acceptée, le corps de la réponse est `json` et le code d’�
   "phone_number": "+447900900123",  # chaîne obligatoire pour les messages texte
   "type" : "email / sms", # chaîne obligatoire
   "status" : "sending / delivered / permanent-failure / temporary-failure / technical-failure", # chaîne obligatoire
+  "provider_response": "STRING", # chaîne facultative - ne sera pas nulle si seulement le statut est une erreur technique
   "template": {
     "Version": 1
     "id": "f33517ff-2a88-4f6e-b855-c550268ce08a" # chaîne obligatoire – ID de modèle
@@ -165,6 +166,7 @@ Si la demande est acceptée, le corps de la réponse est `json` et le code d’�
       "phone_number": "+447900900123",  # chaîne obligatoire pour les messages texte
       "type" : "email / sms", # chaîne obligatoire
       "status" : "sending / delivered / permanent-failure / temporary-failure / technical-failure", # chaîne obligatoire
+      "provider_response": "STRING", # chaîne facultative - ne sera pas nulle si seulement le statut est une erreur technique
       "template": {
         "version": 1
         "id": 'f33517ff-2a88-4f6e-b855-c550268ce08a' # chaîne obligatoire – ID de modèle

--- a/src/fr/rappel.md
+++ b/src/fr/rappel.md
@@ -40,7 +40,7 @@ Le message de la fonction de rappel est formaté en JSON. Toutes les valeurs son
 |`reference` | Référence envoyée par le service | 12345678|
 |`to` | L’adresse de courriel ou numéro de téléphone du destinataire | hello@canada.ca ou 01234567890|
 |`status` | État de la notification | `delivered`, `permanent-failure`, `temporary-failure` ou `technical-failure`|
-|`provider_response` | La réponse détaillée venant du fournisseur. Ceci sera renseigné uniquement lorsque l’état de la notification est une erreur technique | `Blocked as spam by phone carrier`|
+|`provider_response` | La réponse détaillée venant du fournisseur. Ceci sera renseigné uniquement lorsque l’état de la notification est une erreur technique | `Blocked as spam by phone carrier` (ou tout autre message) ou nul|
 |`created_at` | Heure à laquelle le service a envoyé la demande | `2017-05-14T12:15:30.000000Z`|
 |`completed_at` | Dernière mise à jour de l’état | `2017-05-14T12:15:30.000000Z` ou nul|
 |`sent_at` | Heure d’envoi de la notification | `2017-05-14T12:15:30.000000Z` ou nul|

--- a/src/fr/rappel.md
+++ b/src/fr/rappel.md
@@ -40,6 +40,7 @@ Le message de la fonction de rappel est formaté en JSON. Toutes les valeurs son
 |`reference` | Référence envoyée par le service | 12345678|
 |`to` | L’adresse de courriel ou numéro de téléphone du destinataire | hello@canada.ca ou 01234567890|
 |`status` | État de la notification | `delivered`, `permanent-failure`, `temporary-failure` ou `technical-failure`|
+|`provider_response` | La réponse détaillée venant du fournisseur. Ceci sera renseigné uniquement lorsque l'état de la notification est une erreur technique | `Blocked as spam by phone carrier`|
 |`created_at` | Heure à laquelle le service a envoyé la demande | `2017-05-14T12:15:30.000000Z`|
 |`completed_at` | Dernière mise à jour de l’état | `2017-05-14T12:15:30.000000Z` ou nul|
 |`sent_at` | Heure d’envoi de la notification | `2017-05-14T12:15:30.000000Z` ou nul|

--- a/src/fr/rappel.md
+++ b/src/fr/rappel.md
@@ -40,7 +40,7 @@ Le message de la fonction de rappel est formaté en JSON. Toutes les valeurs son
 |`reference` | Référence envoyée par le service | 12345678|
 |`to` | L’adresse de courriel ou numéro de téléphone du destinataire | hello@canada.ca ou 01234567890|
 |`status` | État de la notification | `delivered`, `permanent-failure`, `temporary-failure` ou `technical-failure`|
-|`provider_response` | La réponse détaillée venant du fournisseur. Ceci sera renseigné uniquement lorsque l'état de la notification est une erreur technique | `Blocked as spam by phone carrier`|
+|`provider_response` | La réponse détaillée venant du fournisseur. Ceci sera renseigné uniquement lorsque l’état de la notification est une erreur technique | `Blocked as spam by phone carrier`|
 |`created_at` | Heure à laquelle le service a envoyé la demande | `2017-05-14T12:15:30.000000Z`|
 |`completed_at` | Dernière mise à jour de l’état | `2017-05-14T12:15:30.000000Z` ou nul|
 |`sent_at` | Heure d’envoi de la notification | `2017-05-14T12:15:30.000000Z` ou nul|


### PR DESCRIPTION
Add a new `provider_response` field to:

- callbacks
- when getting a notification's status

See https://github.com/cds-snc/notification-api/pull/1265 for the API PR