### PR TITLE
feat: clarify limits documentation

### DIFF
--- a/src/en/limits.md
+++ b/src/en/limits.md
@@ -2,7 +2,7 @@
 
 ## Rate limits
 
-You’re GC Notify service is limited to doing 1,000 API requests per minute.
+Your GC Notify service is limited to doing 1,000 API requests per minute.
 
 This limit is calculated on a rolling average basis, per API key type. If you exceed the limit, you will get a `429` error `RateLimitError`.
 

--- a/src/en/limits.md
+++ b/src/en/limits.md
@@ -2,9 +2,15 @@
 
 ## Rate limits
 
-You’re limited to sending 1,000 messages per minute.
+You’re limited to doing 1,000 API requests per minute.
 
 This limit is calculated on a rolling basis, per API key type. If you exceed the limit, you will get a `429` error `RateLimitError`.
+
+::: tip Adjusting the API rate limit
+
+This rate limit can be changed if you need. To request an API rate limit increase, [contact us](https://notification.canada.ca/contact).
+
+:::
 
 ## Daily limits
 
@@ -12,13 +18,19 @@ There’s a limit to the number of messages you can send each day:
 
 |Service status|Type of API key|Daily limit|
 |:---|:---|:---|
-|Live|Team or live|10,000|
+|Live|Team or live|Customized according to your needs|
 |Trial|Team|50|
 |Live or trial|Test|Unlimited|
 
-These limits reset at midnight.
+These limits reset at midnight UTC. All team members will receive an email if you reach 80% of your daily limit and if you reach your daily limit.
 
-You can request to go live in settings. To request a limit increase, [contact us](https://www.notification.canada.ca/contact).
+You can request to go live in settings.
+
+::: tip Adjusting your daily limit
+
+The daily limit can be changed if you need. To request a limit increase, [contact us](https://notification.canada.ca/contact).
+
+:::
 
 ## Phone network limits
 

--- a/src/en/limits.md
+++ b/src/en/limits.md
@@ -2,9 +2,9 @@
 
 ## Rate limits
 
-You’re limited to doing 1,000 API requests per minute.
+You’re GC Notify service is limited to doing 1,000 API requests per minute.
 
-This limit is calculated on a rolling basis, per API key type. If you exceed the limit, you will get a `429` error `RateLimitError`.
+This limit is calculated on a rolling average basis, per API key type. If you exceed the limit, you will get a `429` error `RateLimitError`.
 
 ::: tip Adjusting the API rate limit
 
@@ -36,9 +36,9 @@ The daily limit can be changed if you need. To request a limit increase, [contac
 
 If you repeatedly send text messages to the same number the phone networks will block them.
 
-There’s an hourly limit of:
+To prevent spamming there is an hourly limit of:
 
-- 20 messages with the same content
-- 100 messages with any content
+- 20 messages with the same content to the same recipient
+- 100 messages with any content to the same recipient
 
-Your messages may not be delivered if you exceed these limits.
+Your messages may not be delivered if you exceed these limits and your service may be blocked by phone carriers. 

--- a/src/fr/limites.md
+++ b/src/fr/limites.md
@@ -1,10 +1,16 @@
 # Limites
 
-## Nombres limites
+## Limites d’appels à l’API
 
-Vous êtes limité à envoyer 1 000 messages par minute.
+Vous êtes limité à envoyer 1 000 requêtes HTTP par minute.
 
 Cette limite est calculée sur une base continue, par type de clé API. Si vous dépassez la limite, vous obtiendrez une erreur `429` `RateLimitError`.
+
+::: tip Ajuster la limite d’appels à l’API
+
+Cette limite peut être modifiée en fonction de vos besoins. Pour demander une augmentation de la limite, [communiquez avec nous](https://notification.canada.ca/contact?lang=fr).
+
+:::
 
 ## Limites quotidiennes
 
@@ -13,12 +19,18 @@ Il y a une limite au nombre de messages que vous pouvez envoyer chaque jour :
 |État du service|Type de clé d’API|Limite quotidienne|
 |:---|:---|:---|
 |Activé|Équipe ou activé|10 000|
-|En mode d'essai|Équipe|50|
+|En mode d’essai|Équipe|50|
 |Activé ou en mode d'essai|Test|Illimité|
 
-Ces limites sont réinitialisées à minuit.
+Ces limites sont réinitialisées à minuit UTC. Tous les membres de votre service recevront un courriel si vous atteignez 80% de votre limite quotidienne et si votre limite quotidienne est atteinte.
 
-Vous pouvez activer votre service dans les paramètres. Pour demander une augmentation de la limite, [communiquez avec nous](https://notification.canada.ca/contact?lang=fr).
+Vous pouvez activer votre service dans les paramètres.
+
+::: tip Ajuster la limite quotidienne
+
+Votre limite d’envoi quotdienne peut être modifiée en fonction de vos besoins. Pour demander une augmentation de la limite, [communiquez avec nous](https://notification.canada.ca/contact?lang=fr).
+
+:::
 
 ## Limites du réseau téléphonique
 

--- a/src/fr/limites.md
+++ b/src/fr/limites.md
@@ -2,7 +2,7 @@
 
 ## Limites d’appels à l’API
 
-Vous êtes limité à envoyer 1 000 requêtes HTTP par minute.
+Votre service GC Notification peut envoyer 1 000 requêtes HTTP par minute.
 
 Cette limite est calculée sur une base continue, par type de clé API. Si vous dépassez la limite, vous obtiendrez une erreur `429` `RateLimitError`.
 
@@ -36,9 +36,9 @@ Votre limite d’envoi quotdienne peut être modifiée en fonction de vos besoin
 
 Si vous envoyez plusieurs fois des messages texte au même numéro, les réseaux téléphoniques les bloqueront.
 
-Il y a une limite horaire de :
+Pour prévenir le risque de spam, il y a une limite horaire de :
 
-- 20 messages avec le même contenu
-- 100 messages avec tout contenu
+- 20 messages avec le même contenu au même destinataire
+- 100 messages avec tout contenu au même destinataire
 
-Vos messages peuvent ne pas être livrés si vous dépassez ces limites.
+Vos messages peuvent ne pas être livrés si vous dépassez ces limites et votre service pourrait être bloqué par les opérateurs de télécommunications.

--- a/src/fr/limites.md
+++ b/src/fr/limites.md
@@ -18,7 +18,7 @@ Il y a une limite au nombre de messages que vous pouvez envoyer chaque jour :
 
 |État du service|Type de clé d’API|Limite quotidienne|
 |:---|:---|:---|
-|Activé|Équipe ou activé|10 000|
+|Activé|Équipe ou activé|En fonction de vos besoins|
 |En mode d’essai|Équipe|50|
 |Activé ou en mode d'essai|Test|Illimité|
 


### PR DESCRIPTION
Clarify limits:

- API rate limit is about number of HTTP requests, not number of notifications sent
- mention that limits can be changed
- mention that people will receive warnings if they are near/over the daily limit
- mention that daily limits reset at midnight UTC

Preview: https://cds-snc.github.io/notification-documentation/review-apps/limits-warning/6c638b/en/limits.html