### PR TITLE
feat: document multiple callbacks per notification

### DIFF
--- a/src/en/callbacks.md
+++ b/src/en/callbacks.md
@@ -49,7 +49,7 @@ The callback message is formatted in JSON. All of the values are strings. The ke
 
 ::: warning Multiple callbacks for a notification
 
-You might receive multiple callbacks for one notification. For example, the receiving mail server might accept the email (triggering a delivery notification), but after processing the email, the receiving mail server might determine that the email actually results in a bounce (triggering a bounce notification).
+You might receive multiple callbacks for one sent notification. For example, the receiving mail server might accept the email (triggering a delivery notification), but after processing the email, the receiving mail server might determine that the email actually results in a bounce (triggering a bounce notification).
 
 Callbacks are sent in the order they are received.
 

--- a/src/en/callbacks.md
+++ b/src/en/callbacks.md
@@ -47,7 +47,7 @@ The callback message is formatted in JSON. All of the values are strings. The ke
 |`notification_type` | The notification type | `email` or `sms`|
 
 
-::: warning Multiple receipts for a notification
+::: warning Multiple callbacks for a notification
 
 You might receive multiple callbacks for one notification. For example, the receiving mail server might accept the email (triggering a delivery notification), but after processing the email, the receiving mail server might determine that the email actually results in a bounce (triggering a bounce notification).
 

--- a/src/en/callbacks.md
+++ b/src/en/callbacks.md
@@ -45,3 +45,12 @@ The callback message is formatted in JSON. All of the values are strings. The ke
 |`completed_at` | The last time the status was updated | `2017-05-14T12:15:30.000000Z` or nil|
 |`sent_at` | The time the notification was sent | `2017-05-14T12:15:30.000000Z` or nil|
 |`notification_type` | The notification type | `email` or `sms`|
+
+
+::: warning Multiple receipts for a notification
+
+You might receive multiple callbacks for one notification. For example, the receiving mail server might accept the email (triggering a delivery notification), but after processing the email, the receiving mail server might determine that the email actually results in a bounce (triggering a bounce notification).
+
+Callbacks are sent in the order they are received.
+
+:::

--- a/src/fr/rappel.md
+++ b/src/fr/rappel.md
@@ -48,8 +48,8 @@ Le message de la fonction de rappel est formaté en JSON. Toutes les valeurs son
 
 ::: warning Plusieurs fonctions de rappel pour une notification
 
-Vous pouvez recevoir plusieurs plusieurs fonctions de rappel pour une notification. Par exemple, il est possible que le serveur destinataire de courriel accepte le courriel (envoyant une fonction de rappel de livraison réussie), mais après avoir traité le courriel, le serveur courriel peut déterminer qu’en réalité ce courriel résulte en un échec (envoyant une fonction de rappel d’échec).
+Vous pouvez recevoir plusieurs fonctions de rappel pour une seule notification envoyée. Par exemple, il est possible que le serveur de messagerie destinataire accepte le courriel (envoyant une fonction de rappel de livraison réussie), mais après avoir traité le courriel, le serveur de messagerie peut déterminer qu’en réalité ce courriel retourne un échec (envoyant une fonction de rappel d’échec).
 
-Les fonction de rappel sont envoyées dans l’ordre où elles sont reçues.
+Les fonctions de rappel sont envoyées dans l’ordre où elles sont reçues.
 
 :::

--- a/src/fr/rappel.md
+++ b/src/fr/rappel.md
@@ -45,3 +45,11 @@ Le message de la fonction de rappel est formaté en JSON. Toutes les valeurs son
 |`completed_at` | Dernière mise à jour de l’état | `2017-05-14T12:15:30.000000Z` ou nul|
 |`sent_at` | Heure d’envoi de la notification | `2017-05-14T12:15:30.000000Z` ou nul|
 |`notification_type` | Type de notification | `email` ou `sms`|
+
+::: warning Plusieurs fonctions de rappel pour une notification
+
+Vous pouvez recevoir plusieurs plusieurs fonctions de rappel pour une notification. Par exemple, il est possible que le serveur destinataire de courriel accepte le courriel (envoyant une fonction de rappel de livraison réussie), mais après avoir traité le courriel, le serveur courriel peut déterminer qu’en réalité ce courriel résulte en un échec (envoyant une fonction de rappel d’échec).
+
+Les fonction de rappel sont envoyées dans l’ordre où elles sont reçues.
+
+:::


### PR DESCRIPTION
At the moment if we receive multiple delivery receipts for a notification, we ignore new delivery receipts. This is not okay as sometimes email bounce after we receive a delivered callback.

The [SES documentation](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html) says that

> You might receive multiple types of Amazon SNS notifications for one recipient. For example, the receiving mail server might accept the email (triggering a delivery notification), but after processing the email, the receiving mail server might determine that the email actually results in a bounce (triggering a bounce notification). However, these are always separate notifications because they are different notification types.

Trello card: https://trello.com/c/WcEYhnLd/503-store-updated-delivery-status-for-notifications