### PR TITLE
Added a key difference with bulk api between gcnotify and gds notify.

### DIFF
--- a/src/en/clients.md
+++ b/src/en/clients.md
@@ -12,6 +12,7 @@ You will need to change the API endpoint when creating a client.
 ::: warning Feature differences to keep in mind
 
 - [Sending files by email is different with GC Notify](send.md#sending-a-file-by-email)
+- Sending bulk notifications through the GOV.UK Notify clients is not directly supported. You can still use one if the client supports customization of the URL endpoint
 - Sending letters is not available
 - Receiving text messages is not available
 :::

--- a/src/fr/clients.md
+++ b/src/fr/clients.md
@@ -11,6 +11,7 @@ Vous devrez modifier votre point de terminaison :
 ::: warning Différences de fonctionnalités à considérer
 
 - [L'envoi de fichiers par courriel est différent avec GC Notification](envoyer.md#envoyer-un-fichier-par-courriel)
+- L'envoi de notification de masse n'est pas directement supporté par les clients de GOV.UK. Il est toutefois possible d'en utiliser un si celui-ci supporte la personnalisation du chemin de l'adresse HTTP
 - L'envoi de lettres n'est pas disponible
 - La réception de messages texte n'est pas disponible
 :::

--- a/src/fr/clients.md
+++ b/src/fr/clients.md
@@ -11,7 +11,7 @@ Vous devrez modifier votre point de terminaison :
 ::: warning Différences de fonctionnalités à considérer
 
 - [L'envoi de fichiers par courriel est différent avec GC Notification](envoyer.md#envoyer-un-fichier-par-courriel)
-- L'envoi de notification de masse n'est pas directement supporté par les clients de GOV.UK. Il est toutefois possible d'en utiliser un si celui-ci supporte la personnalisation du chemin de l'adresse HTTP
+- La notification de masse n'est pas directement prise en charge par les clients de GOV.UK. Il est toutefois possible d'en utiliser un si celui-ci prend en charge la personnalisation du chemin de l'adresse HTTP
 - L'envoi de lettres n'est pas disponible
 - La réception de messages texte n'est pas disponible
 :::


### PR DESCRIPTION
# Summary | Résumé

Users are using the GDS client libraries to push bulk notifications but these do not directly support our bulk notification feature. This change add that difference between the two implementations on the GDS Notify clients page.

# Help required

Have content team review this please. =)