### PR TITLE
feat: generate Software Bill of Materials

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,7 +73,7 @@ jobs:
         TOKEN: ${{ steps.notify-pr-bot.outputs.token }} 
 
     - name: Generate docker SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@v1
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # renovate: tag=v1
       with:
         dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
         docker_image: $DOCKER_SLUG:${GITHUB_SHA::7}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,7 +73,7 @@ jobs:
         TOKEN: ${{ steps.notify-pr-bot.outputs.token }} 
 
     - name: Generate docker SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@d39a08b2145375940f52c0b4b8c58a8cf3603bdb
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@v1
       with:
         dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
         docker_image: $DOCKER_SLUG:${GITHUB_SHA::7}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -71,3 +71,11 @@ jobs:
     - uses: cds-snc/notification-pr-bot@master
       env:
         TOKEN: ${{ steps.notify-pr-bot.outputs.token }} 
+
+    - name: Generate docker SBOM
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@d39a08b2145375940f52c0b4b8c58a8cf3603bdb
+      with:
+        dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+        docker_image: $DOCKER_SLUG:${GITHUB_SHA::7}
+        project_name: notification-documentation/docker
+        project_type: docker

--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Generate front-end SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@d39a08b2145375940f52c0b4b8c58a8cf3603bdb
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           project_name: notification-documentation/app

--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -1,0 +1,29 @@
+name: Generate SBOM
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - package.json
+      - .github/workflows/generate-sbom.yml
+  push:
+    branches:
+      - main
+    paths:
+      - package.json
+      - .github/workflows/generate-sbom.yml
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate front-end SBOM
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@d39a08b2145375940f52c0b4b8c58a8cf3603bdb
+        with:
+          dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+          project_name: notification-documentation/app
+          project_type: node          

--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Generate front-end SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@v1
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # renovate: tag=v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           project_name: notification-documentation/app

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -37,7 +37,7 @@ jobs:
             github.issues.createComment({ issue_number, owner, repo, body });
 
       - name: Build and deploy review app
-        uses: sauloxd/review-apps@v1.3.3
+        uses: sauloxd/review-apps@v2.0.0
         with:
           build-cmd: 'npm run build'
           branch: 'gh-pages'

--- a/.github/workflows/review-apps.yml
+++ b/.github/workflows/review-apps.yml
@@ -39,7 +39,12 @@ jobs:
       - name: Build and deploy review app
         uses: sauloxd/review-apps@v2.0.0
         with:
-          build-cmd: 'npm run build'
-          branch: 'gh-pages'
-          dist: 'src/.vuepress/dist'
-          slug: 'review-apps'
+          branch: "gh-pages"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          apps: |
+            {
+              "review-apps": {
+                "build": "npm run build",
+                "dist": "src/.vuepress/dist"
+              }
+            }


### PR DESCRIPTION
# Summary
Add GitHub workflows to generate SBOMs and upload them
to Dependency-Track. This will allow us to have a view of all
the dependencies used by the org and their potential
vulnerabilities.

# Related
* cds-snc/platform-sre-security-support#94