### PR TITLE
Update API documentation with updated limits of size and # for file attachments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @AntoineAugusti
+* @jimleroyer
 
-/src/en/ @anikbrazeau
-/src/fr/ @anikbrazeau
+/src/en/ @YedidaZalik
+/src/fr/ @YedidaZalik

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -93,7 +93,7 @@ Sending files by email is an API-only feature. To turn on this feature, [sign in
 
 ### File types and size requirements
 
-You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Microsoft Word Document files. A maximum of 10 file attachments are allowed within one email notification. ~Your email including the file must be smaller than 10MB~.
+You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Microsoft Word Document files. A maximum of 10 file attachments are allowed within one email notification. ~~Your email including the file must be smaller than 10MB~~.
 
 If you need to send other file types, [contact us](https://notification.canada.ca/contact).
 

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -97,7 +97,7 @@ You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Mic
 
 If you need to send other file types, [contact us](https://notification.canada.ca/contact).
 
-::: warning Temporary restriction on overall files size
+::: warning Temporary restriction on overall file size
 
 Due to a recent infrastructure change, the current maximum size for all files and content within an email notification must be smaller than 6MB.
 :::
@@ -222,7 +222,7 @@ If the request to the client is successful, the client returns a `dict`:
 
 ### Error codes
 
-If the request is not successful, the response body is `json`, refer to the table below for details.
+If the request is not successful, the response body is `json`. Refer to the table below for details.
 
 |status_code|message|How to fix|
 |:---|:---|:---|

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -99,7 +99,7 @@ If you need to send other file types, [contact us](https://notification.canada.c
 
 ::: warning Temporary restriction on overall files size
 
-Due to a recent infrastructure changes, the current maximum sizes for all files and content within an email notification must be smaller than 6MB.
+Due to a recent infrastructure change, the current maximum size for all files and content within an email notification must be smaller than 6MB.
 :::
 
 ### Sending methods

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -92,9 +92,15 @@ Sending files by email is an API-only feature. To turn on this feature, [sign in
 :::
 
 ### File types and size requirements
-You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Microsoft Word Document files. Your email including the file must be smaller than 10MB.
+
+You can upload PDF, CSV, .jpeg, .png, .odt, .txt, .rtf,  Microsoft Excel and Microsoft Word Document files. A maximum of 10 file attachments are allowed within one email notification. ~Your email including the file must be smaller than 10MB~.
 
 If you need to send other file types, [contact us](https://notification.canada.ca/contact).
+
+::: warning Temporary restriction on overall files size
+
+Due to a recent infrastructure changes, the current maximum sizes for all files and content within an email notification must be smaller than 6MB.
+:::
 
 ### Sending methods
 

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -93,9 +93,15 @@ Cette fonctionnalité n’est disponible que par le biais de l’API. Pour activ
 :::
 
 ### Types de fichiers et prérequis de taille
-Vous pouvez téléverser des fichiers PDF, CSV, .jpeg, .png, .odt, .txt, .rtf, et des fichiers Microsoft Excel et Microsoft Word. La taille de votre fichier et de votre courriel doit être inférieure à 10 Mo.
+
+Vous pouvez téléverser des fichiers PDF, CSV, .jpeg, .png, .odt, .txt, .rtf, et des fichiers Microsoft Excel et Microsoft Word. Un maximum de 10 pièces jointes est autorisé par courriel. ~La taille de votre fichier et de votre courriel doit être inférieure à 10 Mo~.
 
 Si vous devez envoyer d’autres types de fichiers, [communiquez avec nous](https://notification.canada.ca/contact?lang=fr) .
+
+::: warning Restriction temporaire sur la taille des fichiers
+
+En raison de récents changements d'infrastructure, la taille maximale actuelle de tous les fichiers et du contenu du courriel doit être inférieure à 6 Mo.
+:::
 
 ### Méthodes d’envoi
 

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -221,7 +221,7 @@ Si la demande au client est acceptée, le client renvoie un `dict` :
 
 ### Codes d’erreur
 
-Si la demande a été refusée, le corps de la réponse est `json`, consultez le tableau ci-dessous pour plus de détails.
+Si la demande a été refusée, le corps de la réponse est `json`. Consultez le tableau ci-dessous pour plus de détails.
 
 |status_code|message|Comment réparer|
 |:---|:---|:---|

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -94,7 +94,7 @@ Cette fonctionnalité n’est disponible que par le biais de l’API. Pour activ
 
 ### Types de fichiers et prérequis de taille
 
-Vous pouvez téléverser des fichiers PDF, CSV, .jpeg, .png, .odt, .txt, .rtf, et des fichiers Microsoft Excel et Microsoft Word. Un maximum de 10 pièces jointes est autorisé par courriel. ~La taille de votre fichier et de votre courriel doit être inférieure à 10 Mo~.
+Vous pouvez téléverser des fichiers PDF, CSV, .jpeg, .png, .odt, .txt, .rtf, et des fichiers Microsoft Excel et Microsoft Word. Un maximum de 10 pièces jointes est autorisé par courriel. ~~La taille de votre fichier et de votre courriel doit être inférieure à 10 Mo~~.
 
 Si vous devez envoyer d’autres types de fichiers, [communiquez avec nous](https://notification.canada.ca/contact?lang=fr) .
 

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -100,7 +100,7 @@ Si vous devez envoyer d’autres types de fichiers, [communiquez avec nous](http
 
 ::: warning Restriction temporaire sur la taille des fichiers
 
-En raison de récents changements d'infrastructure, la taille maximale actuelle de tous les fichiers et du contenu du courriel doit être inférieure à 6 Mo.
+En raison d'un récent changement d'infrastructure, la taille maximale actuelle de tous les fichiers et du contenu du courriel doit être inférieure à 6 Mo.
 :::
 
 ### Méthodes d’envoi


### PR DESCRIPTION
# Summary | Résumé

Added warning on current temp file size and max file number, to better inform our users with latest changes in Notify and temporary ones.

[Related zenhub card](https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/659).

# Test instructions | Instructions pour tester la modification

Head over to the review app link. Specifically to these sections:

* [Sending a file by email](https://cds-snc.github.io/notification-documentation/add-file-num-max-and-current-restriction/review-apps/7e49dc/en/send.html#sending-a-file-by-email)
* [Envoyer un fichier par courriel](https://cds-snc.github.io/notification-documentation/add-file-num-max-and-current-restriction/review-apps/7e49dc/fr/envoyer.html#envoyer-un-fichier-par-courriel)
