### PR TITLE
Fix .NET client example that had params in the wrong order

### DIFF
--- a/src/en/_api_endpoints.md
+++ b/src/en/_api_endpoints.md
@@ -11,7 +11,7 @@ NotificationClient client = new NotificationClient(apiKey, "https://api.notifica
 ```vbnet
 using Notify.Client;
 
-var client = new NotificationClient(apiKey, "https://api.notification.canada.ca");
+var client = new NotificationClient("https://api.notification.canada.ca", apiKey);
 ```
 </code-block>
 


### PR DESCRIPTION
# Summary | Résumé

When testing the .NET client library I noticed our documentation had the parameters in the wrong order.  This PR fixes that.
