### PR TITLE
Update instructions for including API keys in headers.

### DIFF
--- a/src/en/start.md
+++ b/src/en/start.md
@@ -14,10 +14,10 @@ The authorization header is an [API key](keys.md). You must include an authoriza
 The header consists of:
 
 ```json
-"Authorization": "ApiKey-v1 YOUR-SECRET-KEY"
+"Authorization": "ApiKey-v1 YOUR-API-KEY"
 ```
 
-That secret key forms a part of your [API key](keys.md), which follows the format `{key_name}-{iss-uuid}-{secret-key-uuid}`.
+Your [API key](keys.md) follows the format `{key_name}-{iss-uuid}-{secret-key-uuid}`.
 
 For example, if your API key is
 `my_test_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0`:
@@ -26,13 +26,14 @@ For example, if your API key is
 * your iss (your service ID) is `26785a09-ab16-4eb0-8407-a37497a57506`
 * your secret key is `3d844edf-8d35-48ac-975b-e847b4f122b0`
 
-Therefore, you would need to set the HTTP header to the following value:
+::: tip NEW: Include the entire API key when calling the API
+&nbsp;
+:::
 
+When calling the API, you need to include your entire API key in the HTTP header:
 ```json
-"Authorization": "ApiKey-v1 3d844edf-8d35-48ac-975b-e847b4f122b0"
+"Authorization": "ApiKey-v1 my_test_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0"
 ```
-
-Note that your secret key is the last 36 characters of your API key.
 
 **Content header**
 

--- a/src/fr/commencer.md
+++ b/src/fr/commencer.md
@@ -26,11 +26,11 @@ Par exemple, si votre clé API est
 * votre ISS (votre ID de service) est `26785a09-ab16-4eb0-8407-a37497a57506`
 * votre clé secrète est `3d844edf-8d35-48ac-975b-e847b4f122b0`
 
-::: tip NOUVEAU: Inclure la clé API entière lors de l'appel de l'API
+::: tip NOUVEAU: Inclure la clé API entière lorsque vous appelez l'API
 &nbsp;
 :::
 
-Vous devez fournir la clé entière dans l’en-tête HTTP lors de l'appel de l'API :
+Vous devez fournir la clé entière dans l’en-tête HTTP lorsque vous appelez l'API :
 
 ```json
 "Authorization": "ApiKey-v1 3d844edf-8d35-48ac-975b-e847b4f122b0"

--- a/src/fr/commencer.md
+++ b/src/fr/commencer.md
@@ -14,10 +14,10 @@ L’en-tête `Authorization` est une [clé API](cles.md). Vous devez inclure un 
 L’en-tête comprend :
 
 ```json
-"Authorization": "ApiKey-v1 VOTRE-CLÉ-SECRÈTE"
+"Authorization": "ApiKey-v1 VOTRE-CLÉ-API"
 ```
 
-Cette clé secrète fait partie de votre [clé API](cles.md), qui suit le format `{nom_clé}-{iss-uuid}-{clé-secrète-uuid}`.
+Cette [clé API](cles.md) suit le format `{nom_clé}-{iss-uuid}-{clé-secrète-uuid}`.
 
 Par exemple, si votre clé API est
 `ma_clé_test-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e84 7b4f122b0`:
@@ -26,13 +26,15 @@ Par exemple, si votre clé API est
 * votre ISS (votre ID de service) est `26785a09-ab16-4eb0-8407-a37497a57506`
 * votre clé secrète est `3d844edf-8d35-48ac-975b-e847b4f122b0`
 
-Par conséquent, vous devez définir l’en-tête HTTP à la valeur suivante :
+::: tip NOUVEAU: Inclure la clé API entière en appellant l'API
+&nbsp;
+:::
+
+En appellant l'API, vous devez fournir la clé entière dans l’en-tête HTTP :
 
 ```json
 "Authorization": "ApiKey-v1 3d844edf-8d35-48ac-975b-e847b4f122b0"
 ```
-
-Veuillez noter que votre clé secrète représente les 36 derniers caractères de votre clé API.
 
 **En-tête de contenu**
 

--- a/src/fr/commencer.md
+++ b/src/fr/commencer.md
@@ -26,11 +26,11 @@ Par exemple, si votre clé API est
 * votre ISS (votre ID de service) est `26785a09-ab16-4eb0-8407-a37497a57506`
 * votre clé secrète est `3d844edf-8d35-48ac-975b-e847b4f122b0`
 
-::: tip NOUVEAU: Inclure la clé API entière en appellant l'API
+::: tip NOUVEAU: Inclure la clé API entière lors de l'appel de l'API
 &nbsp;
 :::
 
-En appellant l'API, vous devez fournir la clé entière dans l’en-tête HTTP :
+Vous devez fournir la clé entière dans l’en-tête HTTP lors de l'appel de l'API :
 
 ```json
 "Authorization": "ApiKey-v1 3d844edf-8d35-48ac-975b-e847b4f122b0"


### PR DESCRIPTION
# Summary | Résumé

Update the instructions around including API keys in headers when calling the API.  Going forward we want users to provide the full API key, so we can be sure they save it along with the prefix.