### PR TITLE
Fix anchor id on clients page

### DIFF
--- a/src/en/clients.md
+++ b/src/en/clients.md
@@ -11,7 +11,7 @@ You will need to change the API endpoint when creating a client.
 
 ::: warning Feature differences to keep in mind
 
-- [Sending files by email is different with GC Notify](send.md#sending-files-by-email-is-an-API-only-feature)
+- [Sending files by email is different with GC Notify](send.md#sending-files-by-email-is-an-api-only-feature)
 - Sending bulk notifications through the GOV.UK Notify clients is not directly supported. You can still use one if the client supports customization of the URL endpoint
 - Sending letters is not available
 - Receiving text messages is not available

--- a/src/fr/clients.md
+++ b/src/fr/clients.md
@@ -10,7 +10,7 @@ Vous devrez modifier votre point de terminaison :
 
 ::: warning Différences de fonctionnalités à considérer
 
-- [L'envoi de fichiers par courriel est différent avec GC Notification](envoyer.md#lenvoi-de-fichiers-par-courriel-est-une-fonctionnalité-unique-à-lapi)
+- [L'envoi de fichiers par courriel est différent avec GC Notification](envoyer.md#l-envoi-de-fichiers-par-courriel-est-une-fonctionnalite-unique-a-l-api)
 - La notification de masse n'est pas directement prise en charge par les clients de GOV.UK. Il est toutefois possible d'en utiliser un si celui-ci prend en charge la personnalisation du chemin de l'adresse HTTP
 - L'envoi de lettres n'est pas disponible
 - La réception de messages texte n'est pas disponible


### PR DESCRIPTION
This PR fixes the anchor on the client page so that it links properly back to the send page.