### PR TITLE
fix

### DIFF
--- a/src/en/send.md
+++ b/src/en/send.md
@@ -24,8 +24,8 @@ Your API call must also include any fields that have been set up as personalisat
 ## Check status, repair and resend messages
 
 If your HTTP requests receive a:
-1. 4** class error for an invalid request.
-1. 5** class error for server failure.
+1. 4xx class error for an invalid request.
+1. 5xx class error for server failure.
 
 GC Notify treats these errors as unprocessed requests. Requests must receive 2** class success in order for GC Notify to retry until sending is done.
 Restrict requests to GC Notify’s API to 1000 per minute. You’ll get a 429 error if you exceed this number.

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -27,7 +27,7 @@ If your HTTP requests receive a:
 1. 4xx class error for an invalid request.
 1. 5xx class error for server failure.
 
-GC Notify treats these errors as unprocessed requests. Requests must receive 2** class success in order for GC Notify to retry until sending is done.
+GC Notify treats these errors as unprocessed requests. Requests must receive 2xx class success in order for GC Notify to retry until sending is done.
 Restrict requests to GC Notify’s API to 1000 per minute. You’ll get a 429 error if you exceed this number.
 
 ## Sending an email

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -21,11 +21,11 @@ Your API call must also include any fields that have been set up as personalisat
 - Send a unique transaction number as a follow up
 - Give users a dynamically generated list of actions they need to take
 
-**Check status, repair and resend messages**
+## Check status, repair and resend messages
 
 If your HTTP requests receive a:
 1. 4** class error for an invalid request.
-1. 5** class error for server failure.\
+1. 5** class error for server failure.
 
 GC Notify treats these errors as unprocessed requests. Requests must receive 2** class success in order for GC Notify to retry until sending is done.
 Restrict requests to GC Notify’s API to 1000 per minute. You’ll get a 429 error if you exceed this number.

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -24,8 +24,8 @@ Votre appel à l'API doit également inclure tous les champs qui ont été confi
 ## Vérifiez l’état du message, corrigez et envoyez à nouveau**
 
 Si vous obtenez pour vos requêtes HTTP:
-1. une erreur de classe 4** correspondant à une requête invalide; ou
-1. une erreur de classe 5** correspondant à un échec du serveur,
+1. une erreur de classe 4xx correspondant à une requête invalide; ou
+1. une erreur de classe 5xx correspondant à un échec du serveur,
 
 Notification GC traite ces erreurs comme des demandes non traitées. Pour que Notification GC puisse réessayer jusqu’à ce que l’envoi soit effectué, les demandes doivent obtenir un succès de classe 2**.
 Limitez les requêtes à l’API de Notification GC à 1 000 par minute. Si vous dépassez ce nombre, vous obtiendrez une erreur 429.

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -21,13 +21,13 @@ Votre appel à l'API doit également inclure tous les champs qui ont été confi
 - Envoyer un numéro de transaction unique comme suivi
 - Donner aux utilisateurs une liste dynamique des mesures qu’ils doivent prendre
 
-## Vérifiez l’état du message, corrigez et envoyez à nouveau**
+## Vérifiez l’état du message, corrigez et envoyez à nouveau
 
 Si vous obtenez pour vos requêtes HTTP:
 1. une erreur de classe 4xx correspondant à une requête invalide; ou
 1. une erreur de classe 5xx correspondant à un échec du serveur,
 
-Notification GC traite ces erreurs comme des demandes non traitées. Pour que Notification GC puisse réessayer jusqu’à ce que l’envoi soit effectué, les demandes doivent obtenir un succès de classe 2**.
+Notification GC traite ces erreurs comme des demandes non traitées. Pour que Notification GC puisse réessayer jusqu’à ce que l’envoi soit effectué, les demandes doivent obtenir un succès de classe 2xx.
 Limitez les requêtes à l’API de Notification GC à 1 000 par minute. Si vous dépassez ce nombre, vous obtiendrez une erreur 429.
 
 ## Envoyer un courriel

--- a/src/fr/envoyer.md
+++ b/src/fr/envoyer.md
@@ -21,11 +21,11 @@ Votre appel à l'API doit également inclure tous les champs qui ont été confi
 - Envoyer un numéro de transaction unique comme suivi
 - Donner aux utilisateurs une liste dynamique des mesures qu’ils doivent prendre
 
-**Vérifiez l’état du message, corrigez et envoyez à nouveau**
+## Vérifiez l’état du message, corrigez et envoyez à nouveau**
 
 Si vous obtenez pour vos requêtes HTTP:
 1. une erreur de classe 4** correspondant à une requête invalide; ou
-1. une erreur de classe 5** correspondant à un échec du serveur,\
+1. une erreur de classe 5** correspondant à un échec du serveur,
 
 Notification GC traite ces erreurs comme des demandes non traitées. Pour que Notification GC puisse réessayer jusqu’à ce que l’envoi soit effectué, les demandes doivent obtenir un succès de classe 2**.
 Limitez les requêtes à l’API de Notification GC à 1 000 par minute. Si vous dépassez ce nombre, vous obtiendrez une erreur 429.


### PR DESCRIPTION
# Summary | Résumé

Fix error messages

Fixed the following: 
(1) there's a backslash " \ "that should not be there. It's after the word failure in the second bullet.
(2) the subheading "Check status, repair and resend messages" should be an H2 like