### PR TITLE
use correct pr-bot branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,7 +79,7 @@ jobs:
         app_id: ${{ secrets.NOTIFY_PR_BOT_APP_ID }}
         private_key: ${{ secrets.NOTIFY_PR_BOT_PRIVATE_KEY }}
 
-    - uses: cds-snc/notification-pr-bot@master
+    - uses: cds-snc/notification-pr-bot@main
       env:
         TOKEN: ${{ steps.notify-pr-bot.outputs.token }} 
 


### PR DESCRIPTION
# Summary | Résumé

when we merge to main we kick off the pr-bot to make a release PR in the manifest repo. However we're running the `master` branch of the pr-bot rather than the `main` branch (which we switched to a year ago). This old branch doesn't work:
```
Run cds-snc/notification-pr-bot@master
(node:1955) UnhandledPromiseRejectionWarning: TypeError: Cannot read property '0' of null
    at /home/runner/work/_actions/cds-snc/notification-pr-bot/master/dist/index.js:290:54
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Promise.all (index 4)
    at async hydrateWithSHAs (/home/runner/work/_actions/cds-snc/notification-pr-bot/master/dist/index.js:273:10)
    at async run (/home/runner/work/_actions/cds-snc/notification-pr-bot/master/dist/index.js:310:3)
(node:1955) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
```

- The impact of this means that when the this repo changes pr-bot doesn't update the release PR in the manifest repo.
- However, when another repo runs pr-bot, the changes here will get added. 
- So production is up to date right now (except for the very latest release of this repo).

Regardless, we should fix this.

Note that I've checked our other repos and they are all using the `main` branch of pr-bot.