### PR TITLE
Change Status to Status Description in table headings

### DIFF
--- a/src/en/status.md
+++ b/src/en/status.md
@@ -7,7 +7,7 @@ Message status depends on the type of message you have sent.
 You can only get the status of messages that are 7 days old or newer (by default). Data retention can be configured to be anywhere between 3 and 90 days at either the service or notification level.
 
 ## Email status
-|Status|Information|
+|Status Description|Information|
 |:---|:---|
 |Created|GC Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
 |In transit|GC Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GC Notify is waiting for delivery information.|
@@ -18,7 +18,7 @@ You can only get the status of messages that are 7 days old or newer (by default
 
 ## Text message status
 
-|Status|Information|
+|Status Description|Information|
 |:---|:---|
 |Created|GC Notify has placed the message in a queue, ready to be sent to the provider. It should only remain in this state for a few seconds.|
 |In transit|GC Notify has sent the message to the provider. The provider will try to deliver the message to the recipient for up to 72 hours. GC Notify is waiting for delivery information.|

--- a/src/fr/etat.md
+++ b/src/fr/etat.md
@@ -8,7 +8,7 @@ Vous ne pouvez obtenir que l’état des messages qui ont été envoyés durant 
 
 ## État du courriel
 
-|État|Renseignements|
+|Description de l'état|Renseignements|
 |:---|:---|
 |Créé|Notification GC a placé le message dans une file d’attente, prêt à être envoyé au fournisseur. Il ne doit rester dans cet état que quelques secondes.|
 |Envoi en cours|Notification GC a envoyé le message au fournisseur. Le fournisseur essaiera d’envoyer le message au destinataire pendant une période maximale de 72 heures. Notification GC attend les renseignements de livraison.|
@@ -18,7 +18,7 @@ Vous ne pouvez obtenir que l’état des messages qui ont été envoyés durant 
 
 ## État du message texte
 
-|État|Renseignements|
+|Description de l'état|Renseignements|
 |:---|:---|
 |Créé|Notification GC a placé le message dans une file d’attente, prêt à être envoyé au fournisseur. Il ne doit rester dans cet état que quelques secondes.|
 |Envoi en cours|Notification GC a envoyé le message au fournisseur. Le fournisseur essaiera d’envoyer le message au destinataire pendant une période maximale de 72 heures. Notification GC attend les renseignements de livraison.|


### PR DESCRIPTION
# Summary | Résumé
This PR is supplemental to the changes in: https://github.com/cds-snc/notification-admin/pull/1633.

- Changes the table headings in `etat.md` and `status.md` from `Status` to `Status Description`.