### PR TITLE
Ensure the current page is not navigated away from when changing lang

### DIFF
--- a/src/.vuepress/theme/components/NavLinks.vue
+++ b/src/.vuepress/theme/components/NavLinks.vue
@@ -52,7 +52,24 @@ export default {
 
   computed: {
     userNav () {
-      return this.$themeLocaleConfig.nav || this.$site.themeConfig.nav || []
+      const mappings = [
+        {"en": "/en/", "fr": "/fr/",},
+        {"en": "/en/start", "fr": "/fr/commencer"},
+        {"en": "/en/send", "fr": "/fr/envoyer"},
+        {"en": "/en/status", "fr": "/fr/etat"},
+        {"en": "/en/testing", "fr": "/fr/essai"},
+        {"en": "/en/keys", "fr": "/fr/cles"},
+        {"en": "/en/limits", "fr": "/fr/limites"},
+        {"en": "/en/callbacks", "fr": "/fr/rappel"},
+        {"en": "/en/architecture", "fr": "/fr/architecture"},
+        {"en": "/en/clients", "fr": "/fr/clients"},
+      ]
+      const currentUrl = this.$page.path.split(".html")[0]
+      const lang = currentUrl.split('/')[1]
+      const otherLang = {"en": "fr", "fr": "en"}[lang]
+      const url = mappings.find(url => url[lang] == currentUrl)
+
+      return [{"text": lang == 'fr' ? "English" : "Français", "link": url[otherLang], "type": "link", "items": []}]
     },
 
     nav () {

--- a/src/.vuepress/theme/components/NavLinks.vue
+++ b/src/.vuepress/theme/components/NavLinks.vue
@@ -53,7 +53,8 @@ export default {
   computed: {
     userNav () {
       const mappings = [
-        {"en": "/en/", "fr": "/fr/",},
+        {"en": "/", "fr": "/"},
+        {"en": "/en/", "fr": "/fr/"},
         {"en": "/en/start", "fr": "/fr/commencer"},
         {"en": "/en/send", "fr": "/fr/envoyer"},
         {"en": "/en/status", "fr": "/fr/etat"},
@@ -63,17 +64,25 @@ export default {
         {"en": "/en/callbacks", "fr": "/fr/rappel"},
         {"en": "/en/architecture", "fr": "/fr/architecture"},
         {"en": "/en/clients", "fr": "/fr/clients"},
+        {"en": "/en/_api_endpoints", "fr": "/fr/clients"},
+        {"en": "/en/_arg_template_id", "fr": "/fr/_arg_template_id"},
       ]
       const currentUrl = this.$page.path.split(".html")[0]
       const lang = currentUrl.split('/')[1]
+      // Workaround: During building, VuePress checks NavLinks against known routes
+      // In this method we depend on /en/ or /fr/ to exist in the url. This is not the case
+      // for the root "/". Once the app is running, "/" redirects to either '/en/' or '/fr/'
+      // this "context" isn't available during the build process, similar to how the window object
+      // is not available during a build and hence will fail if we used it here to get the current url.
+      if (lang == '') return this.$themeLocaleConfig.nav || this.$site.themeConfig.nav || []
       const otherLang = {"en": "fr", "fr": "en"}[lang]
       const url = mappings.find(url => url[lang] == currentUrl)
-
-      return [{"text": lang == 'fr' ? "English" : "Français", "link": url[otherLang], "type": "link", "items": []}]
+      const txt = lang == 'fr' ? "English" : "Français"
+      const link = url[otherLang]
+      return [{"text": txt, "link": link, "type": "link", "items": []}]
     },
 
     nav () {
-      const { locales } = this.$site
       return this.userNav
     },
 


### PR DESCRIPTION
# Summary | Résumé
This PR changes the way the `href` for the language toggle is built. Instead of forwarding the user back to the index page, it will now look at and use the current url to build the `href`. Toggling the language should now "remember" what page the user was on when they toggled the language.

A future PR is planned to also maintain the state of the current anchor tag in the URL and automatically scroll the user back to the sub-section they were on before toggling the language.

# Test instructions | Instructions pour tester la modification
1. Navigate to any page in the documentation other than the landing / index page
2. Toggle the language via the link in the upper right corner
3. Note that you were not redirected back to the index page but instead are on the same page you were on before toggling the language.