### PR TITLE
Changed 90 days max retention to 7 in order to reflect our policies

### DIFF
--- a/src/en/status.md
+++ b/src/en/status.md
@@ -4,7 +4,7 @@ You can use the GC Notify API to retrieve the status of one or more messages.
 
 Message status depends on the type of message you have sent.
 
-You can only get the status of messages that are 7 days old or newer (by default). Data retention can be configured to be anywhere between 3 and 90 days at either the service or notification level.
+You can only get the status of messages that are 7 days old or newer (by default). Data retention can be configured to be anywhere between 3 and 7 days at either the service or notification level.
 
 ## Email status
 |Status Description|Information|
@@ -96,7 +96,7 @@ You can use the GC Notify API to find the status of multiple messages at the sam
 
 This API call returns one page of up to 250 messages and statuses. You can get either the most recent messages, or get older messages by specifying a particular notification ID in the `older_than` argument.
 
-You can only get the status of messages that are 7 days old or newer (by default). Data retention can be configured to be anywhere between 3 and 90 days at either the service or notification level.
+You can only get the status of messages that are 7 days old or newer (by default). Data retention can be configured to be anywhere between 3 and 7 days at either the service or notification level.
 
 ```
 GET /v2/notifications

--- a/src/fr/etat.md
+++ b/src/fr/etat.md
@@ -4,7 +4,7 @@ Vous pouvez utiliser l’API Notification GC pour récupérer l’état d’un o
 
 L’état du message dépend du type de message que vous avez envoyé.
 
-Vous ne pouvez obtenir que l’état des messages qui ont été envoyés durant les 7 derniers jours. La retention des données peut être configurée pour être entre 3 et 90 jours, soit au niveau du service, soit au niveau de la notification.
+Vous ne pouvez obtenir que l’état des messages qui ont été envoyés durant les 7 derniers jours. La retention des données peut être configurée pour être entre 3 et 7 jours, soit au niveau du service, soit au niveau de la notification.
 
 ## État du courriel
 
@@ -95,7 +95,7 @@ Vous pouvez utiliser l’API de Notification GC pour rechercher simultanément l
 
 Cet appel d’API renvoie une page d’un maximum de 250 messages et états. Vous pouvez obtenir les messages les plus récents ou obtenir des messages plus anciens en indiquant un ID de notification particulier dans l’argument `older_than`.
 
-Vous ne pouvez obtenir que l’état des messages qui ont été envoyés durant les 7 derniers jours. La retention des données peut être configurée pour être entre 3 et 90 jours, soit au niveau du service, soit au niveau de la notification.
+Vous ne pouvez obtenir que l’état des messages qui ont été envoyés durant les 7 derniers jours. La retention des données peut être configurée pour être entre 3 et 7 jours, soit au niveau du service, soit au niveau de la notification.
 
 ```
 GET /v2/notifications


### PR DESCRIPTION
# Summary | Résumé

Changed 90 days max retention to 7 in order to reflect our policies. A ticket on support asked us to raise the data retention higher than 7 days but our current policies do not support that.
