### PR TITLE
Add api key prefix requirement to docs

### DIFF
--- a/src/en/start.md
+++ b/src/en/start.md
@@ -20,9 +20,9 @@ The header consists of:
 Your [API key](keys.md) follows the format `{prefix}-{key_name}-{iss-uuid}-{secret-key-uuid}`.
 
 For example, if your API key is
-`gcntfy-my_test_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0`:
+`ApiKey-v1 gcntfy-my_test_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0`:
 
-* your API key prefix is `gcntfy`
+* your API key prefix is `ApiKey-v1 gcntfy`
 * your API key name is `my_test_key`
 * your iss (your service ID) is `26785a09-ab16-4eb0-8407-a37497a57506`
 * your secret key is `3d844edf-8d35-48ac-975b-e847b4f122b0`

--- a/src/en/start.md
+++ b/src/en/start.md
@@ -17,22 +17,20 @@ The header consists of:
 "Authorization": "ApiKey-v1 YOUR-API-KEY"
 ```
 
-Your [API key](keys.md) follows the format `{key_name}-{iss-uuid}-{secret-key-uuid}`.
+Your [API key](keys.md) follows the format `{prefix}-{key_name}-{iss-uuid}-{secret-key-uuid}`.
 
 For example, if your API key is
-`my_test_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0`:
+`gcntfy-my_test_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0`:
 
+* your API key prefix is `gcntfy`
 * your API key name is `my_test_key`
 * your iss (your service ID) is `26785a09-ab16-4eb0-8407-a37497a57506`
 * your secret key is `3d844edf-8d35-48ac-975b-e847b4f122b0`
 
-::: tip NEW: Include the entire API key when calling the API
-&nbsp;
-:::
-
 When calling the API, you need to include your entire API key in the HTTP header:
+
 ```json
-"Authorization": "ApiKey-v1 my_test_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0"
+"Authorization": "ApiKey-v1 gcntfy-my_test_key-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0"
 ```
 
 **Content header**

--- a/src/fr/commencer.md
+++ b/src/fr/commencer.md
@@ -20,9 +20,9 @@ L’en-tête comprend :
 Cette [clé API](cles.md) suit le format `{préfixe}-{nom_clé}-{iss-uuid}-{clé-secrète-uuid}`.
 
 Par exemple, si votre clé API est
-`gcntfy-ma_clé_test-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0`:
+`ApiKey-v1 gcntfy-ma_clé_test-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0`:
 
-* votre préfixe de clé API est `gcntfy`
+* votre préfixe de clé API est `ApiKey-v1 gcntfy`
 * votre nom de clé API est `ma_clé_test`
 * votre ISS (votre ID de service) est `26785a09-ab16-4eb0-8407-a37497a57506`
 * votre clé secrète est `3d844edf-8d35-48ac-975b-e847b4f122b0`

--- a/src/fr/commencer.md
+++ b/src/fr/commencer.md
@@ -20,7 +20,7 @@ L’en-tête comprend :
 Cette [clé API](cles.md) suit le format `{préfixe}-{nom_clé}-{iss-uuid}-{clé-secrète-uuid}`.
 
 Par exemple, si votre clé API est
-`gcntfy-ma_clé_test-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e84 7b4f122b0`:
+`gcntfy-ma_clé_test-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0`:
 
 * votre préfixe de clé API est `gcntfy`
 * votre nom de clé API est `ma_clé_test`
@@ -30,7 +30,7 @@ Par exemple, si votre clé API est
 Vous devez fournir la clé entière dans l’en-tête HTTP lorsque vous appelez l'API :
 
 ```json
-"Authorization": "ApiKey-v1 gcntfy-ma_clé_test-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e84 7b4f122b0"
+"Authorization": "ApiKey-v1 gcntfy-ma_clé_test-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e847b4f122b0"
 ```
 
 **En-tête de contenu**

--- a/src/fr/commencer.md
+++ b/src/fr/commencer.md
@@ -17,23 +17,20 @@ L’en-tête comprend :
 "Authorization": "ApiKey-v1 VOTRE-CLÉ-API"
 ```
 
-Cette [clé API](cles.md) suit le format `{nom_clé}-{iss-uuid}-{clé-secrète-uuid}`.
+Cette [clé API](cles.md) suit le format `{préfixe}-{nom_clé}-{iss-uuid}-{clé-secrète-uuid}`.
 
 Par exemple, si votre clé API est
-`ma_clé_test-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e84 7b4f122b0`:
+`gcntfy-ma_clé_test-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e84 7b4f122b0`:
 
+* votre préfixe de clé API est `gcntfy`
 * votre nom de clé API est `ma_clé_test`
 * votre ISS (votre ID de service) est `26785a09-ab16-4eb0-8407-a37497a57506`
 * votre clé secrète est `3d844edf-8d35-48ac-975b-e847b4f122b0`
 
-::: tip NOUVEAU: Inclure la clé API entière lorsque vous appelez l'API
-&nbsp;
-:::
-
 Vous devez fournir la clé entière dans l’en-tête HTTP lorsque vous appelez l'API :
 
 ```json
-"Authorization": "ApiKey-v1 3d844edf-8d35-48ac-975b-e847b4f122b0"
+"Authorization": "ApiKey-v1 gcntfy-ma_clé_test-26785a09-ab16-4eb0-8407-a37497a57506-3d844edf-8d35-48ac-975b-e84 7b4f122b0"
 ```
 
 **En-tête de contenu**


### PR DESCRIPTION
# Summary | Résumé
- Remove the “New” banner on the guidance in the API documentation, under Get Started as it isn’t new anymore
- Examples of API keys now include the `gcntf` prefix
- Added a bullet to explain how the prefix fits in the key format.