### PR TITLE
Moving Staging Kubernetes Rollout to Manifests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,7 @@ env:
   AWS_REGION: ca-central-1
   DOCKER_ORG: public.ecr.aws/cds-snc
   DOCKER_SLUG: public.ecr.aws/cds-snc/notify-documentation
+  WORKFLOW_PAT: ${{ secrets.WORKFLOW_GITHUB_PAT }}
 
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,6 @@ env:
   AWS_REGION: ca-central-1
   DOCKER_ORG: public.ecr.aws/cds-snc
   DOCKER_SLUG: public.ecr.aws/cds-snc/notify-documentation
-  KUBECTL_VERSION: '1.18.0'
 
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT
@@ -26,13 +25,6 @@ jobs:
         unzip -q awscliv2.zip
         sudo ./aws/install --update
         aws --version
-    - name: Install kubectl
-      run: |
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl
-        chmod +x ./kubectl
-        sudo mv ./kubectl /usr/local/bin/kubectl
-        kubectl version --client
-        mkdir -p $HOME/.kube
 
     - name: Configure credentials to CDS public ECR using OIDC
       uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
@@ -58,20 +50,15 @@ jobs:
       run: |
         docker push $DOCKER_SLUG:latest && docker push $DOCKER_SLUG:${GITHUB_SHA::7}
 
-    - name: Configure credentials to Notify account using OIDC
-      uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
-      with:
-        role-to-assume: arn:aws:iam::239043911459:role/notification-documentation-apply
-        role-session-name: NotifyDocumentationGitHubActions
-        aws-region: "ca-central-1"
-
-    - name: Get Kubernetes configuration
+    - name: Rollout in Kubernetes
       run: |
-        aws eks --region $AWS_REGION update-kubeconfig --name notification-canada-ca-staging-eks-cluster --kubeconfig $HOME/.kube/config
-    - name: Update image in staging
-      run: |
-        kubectl set image deployment.apps/documentation documentation=$DOCKER_SLUG:${GITHUB_SHA::7} -n=notification-canada-ca --kubeconfig=$HOME/.kube/config
-    
+        PAYLOAD={\"ref\":\"main\",\"inputs\":{\"docker_sha\":\"${GITHUB_SHA::7}\"}}
+        curl -L -X POST -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer $WORKFLOW_PAT" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/cds-snc/notification-manifests/actions/workflows/documentation-rollout-k8s-staging.yaml/dispatches \
+          -d $PAYLOAD
+   
     - name: my-app-install token
       id: notify-pr-bot
       uses: getsentry/action-github-app-token@38a3ce582e170ddfe8789f509597c6944f2292a9 # v1.0.6


### PR DESCRIPTION
# Summary | Résumé

This will replace the K8s rollout code in the docker build and push GitHub action with a remote call to the manifests repository, which now has the admin rollout github action. This is in preparation for the move to a private EKS endpoint.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/293

# Test instructions | Instructions pour tester la modification

This unfortunately can't be tested until after merge.
- [ ]  Verify that this Github action and the corresponding github action in Notification-Manifests works as expected.

# Release Instructions | Instructions pour le déploiement

- [ ] [Ensure that this PR is merged before merging this PR](https://github.com/cds-snc/notification-manifests/pull/2443)

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
