### PR TITLE
Add callback docs on suspensions and API performance

### DIFF
--- a/src/en/callbacks.md
+++ b/src/en/callbacks.md
@@ -26,7 +26,7 @@ When creating a `Bearer` token, you should:
 - Make sure that callbacks you receive from GC Notify contain your bearer token in the `Authorization` header
 - Use a hashed value so that GC Notify doesn't hold the true token
 
-::: warning Health check requests
+## Health check requests
 
 GC Notify sends health check requests to the URL you provided, to verify that we can reach and receive a response from your API.
 
@@ -35,7 +35,6 @@ GC Notify sends health check requests to the URL you provided, to verify that we
     "health_check": "true"
 }
 ```
-:::
 
 We send these health checks when you:
 

--- a/src/en/callbacks.md
+++ b/src/en/callbacks.md
@@ -35,7 +35,6 @@ GC Notify sends health check requests to the URL you provided, to verify that we
     "health_check": "true"
 }
 ```
-
 :::
 
 We send these health checks when you:

--- a/src/en/callbacks.md
+++ b/src/en/callbacks.md
@@ -44,16 +44,27 @@ We send these health checks when you:
 - Update a callback configuration.
 - Test your service's response time via the callbacks page.
 
+:::tip GC Notify offers API response time testing
+
+You can access it directly from our website. From your service dashboard, visit `API Integration > Callbacks`.
+:::
+
 ## Maintaining your callbacks
 
-When you set up API callbacks for your GCNotify service, make sure that your API **has consistent uptime** and **can respond within 1 second.**
+When you set up API callbacks for your GCNotify service, make sure that your API has **consistent uptime** and can respond within **1 second.** It is important to:
+
+- Maintain adequate API logging to help you diagnose issues.
+- Identify and address bottlenecks in your code and infrastructure.
+- Monitor and test your API's response times.
 
 
-If GC Notify has **periodic** problems delivering callbacks to your API, we will send you an email to let you know of any performance degradations.
+### Delivery retries and suspensions
+
+GC Notify continues trying to deliver until a callback fails 25 times in 5 minutes. After that, we'll email to inform you there's a problem with your API.
 
 ::: warning Temporary suspensions
 
-If GC Notify has **frequent** problems delivering callbacks to your API, we may **temporarily suspend callback deliveries for your service** and send you an email with steps to resolve the suspension.
+If GC Notify has **frequent** problems delivering callbacks to your API, we may **temporarily suspend callback deliveries for your service and send you an email with steps to resolve the suspension.
 
 :::
 

--- a/src/en/callbacks.md
+++ b/src/en/callbacks.md
@@ -26,6 +26,38 @@ When creating a `Bearer` token, you should:
 - Make sure that callbacks you receive from GC Notify contain your bearer token in the `Authorization` header
 - Use a hashed value so that GC Notify doesn't hold the true token
 
+::: warning Health check requests
+
+GC Notify sends health check requests to the URL you provided, to verify that we can reach and receive a response from your API.
+
+```json
+{
+    "health_check": "true"
+}
+```
+
+:::
+
+We send these health checks when you:
+
+- Set up callbacks.
+- Update a callback configuration.
+- Test your service's response time via the callbacks page.
+
+## Maintaining your callbacks
+
+When you set up API callbacks for your GCNotify service, make sure that your API **has consistent uptime** and **can respond within 1 second.**
+
+
+If GC Notify has **periodic** problems delivering callbacks to your API, we will send you an email to let you know of any performance degradations.
+
+::: warning Temporary suspensions
+
+If GC Notify has **frequent** problems delivering callbacks to your API, we may **temporarily suspend callback deliveries for your service** and send you an email with steps to resolve the suspension.
+
+:::
+
+
 ## Message delivery receipts
 
 When you send an email or text message, GC Notify will send a receipt to your callback URL to tell you if it was delivered or not. This is an automated method to get the status of messages.

--- a/src/fr/rappel.md
+++ b/src/fr/rappel.md
@@ -26,6 +26,48 @@ Lors de la création d’un jeton `Bearer`, vous devez :
 - Assurez-vous que les fonctions de rappel que vous recevez de Notification GC contiennent votre jeton `Bearer` dans l’en-tête `Authorization`
 - utiliser une valeur hachée pour que Notification GC ne contienne pas le vrai jeton
 
+::: warning Demandes de bilan de santé
+
+Notification GC envoie des demandes de bilan de santé à l’URL que vous avez fournie afin de vérifier que nous pouvons joindre votre API et recevoir une réponse de sa part.
+
+```json
+{
+    "health_check": "true"
+}
+```
+
+:::
+
+Nous vous envoyons ces bilans de santé lorsque vous :
+
+- configurez des rappels;
+- mettez à jour une configuration de rappel; et
+- testez le temps de réponse de votre service via la page des rappels.
+
+:::tip Notification GC vous permet de tester le temps de réponse de votre API
+
+Vous pouvez accéder à cette fonctionnalité directement depuis notre site Web. À partir du tableau de bord de votre service, rendez-vous dans la section « Intégration API » puis dans « Fonctions de rappel ».
+
+:::
+
+## Maintenance de vos fonctions de rappel
+
+Lorsque vous configurez les rappels d’API pour votre service Notification GC, vérifiez que votre API offre un temps de fonctionnement constant et peut répondre dans un délai d’une seconde. Il est important de :
+
+- maintenir des journaux d’activité adéquats concernant votre API pour vous aider à diagnostiquer les problèmes;
+- reconnaître les goulots d'étranglement au sein de votre code et de votre infrastructure et d’y remédier; et de
+- surveiller et tester les temps de réponse de votre API.
+
+## Tentatives d’envoi et suspensions
+
+Notification GC continuera ses tentatives d’envoi jusqu’à ce qu’une fonction de rappel échoue 25 fois en 5 minutes. Après quoi, nous vous informerons par courriel qu’il y a un problème avec votre API.
+
+::: warning Suspensions temporaires
+
+Si Notification GC rencontre fréquemment des problèmes concernant l’envoi de rappels à votre API, nous pouvons suspendre temporairement ces envois pour votre service et vous envoyer un courriel détaillant les étapes à suivre pour mettre fin à la suspension.
+
+:::
+
 ## Accusés de réception de message
 
 Lorsque vous envoyez un courriel ou un message texte, Notification GC envoie un accusé de réception à votre adresse URL de rappel pour vous dire s’il a été livré ou non. Il s’agit d’une méthode automatisée pour obtenir l’état des messages.

--- a/src/fr/rappel.md
+++ b/src/fr/rappel.md
@@ -26,7 +26,7 @@ Lors de la création d’un jeton `Bearer`, vous devez :
 - Assurez-vous que les fonctions de rappel que vous recevez de Notification GC contiennent votre jeton `Bearer` dans l’en-tête `Authorization`
 - utiliser une valeur hachée pour que Notification GC ne contienne pas le vrai jeton
 
-::: warning Demandes de bilan de santé
+## Demandes de bilan de santé
 
 Notification GC envoie des demandes de bilan de santé à l’URL que vous avez fournie afin de vérifier que nous pouvons joindre votre API et recevoir une réponse de sa part.
 
@@ -36,17 +36,16 @@ Notification GC envoie des demandes de bilan de santé à l’URL que vous avez 
 }
 ```
 
-:::
-
 Nous vous envoyons ces bilans de santé lorsque vous :
 
 - configurez des rappels;
 - mettez à jour une configuration de rappel; et
 - testez le temps de réponse de votre service via la page des rappels.
 
+
 :::tip Notification GC vous permet de tester le temps de réponse de votre API
 
-Vous pouvez accéder à cette fonctionnalité directement depuis notre site Web. À partir du tableau de bord de votre service, rendez-vous dans la section « Intégration API » puis dans « Fonctions de rappel ».
+Vous pouvez accéder à cette fonctionnalité directement depuis notre site Web. À partir du tableau de bord de votre service, rendez-vous dans la section « Intégration API » puis dans <span style="white-space: nowrap;">« Fonctions de rappel ».</span>
 
 :::
 


### PR DESCRIPTION
# Summary | Résumé

This PR adds documentation on callback suspensions and the performance expectations for services that we callback to.


# Test instructions | Instructions pour tester la modification


# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
