### PR TITLE
fix: use CDS Trivy vulnerability database

### DIFF
--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -32,7 +32,9 @@ jobs:
           registry-type: public
 
       - name: Docker vulnerability scan
-        uses: cds-snc/security-tools/.github/actions/docker-scan@cfec0943e40dbb78cee115bbbe89dc17f07b7a0f # v2.1.3
+        uses: cds-snc/security-tools/.github/actions/docker-scan@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+        env:
+          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
         with:
           docker_image: "${{ env.DOCKER_SLUG }}:latest"
           dockerfile_path: "Dockerfile"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,7 +100,9 @@ jobs:
         TOKEN: ${{ steps.notify-pr-bot.outputs.token }} 
 
     - name: Generate docker SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@cfec0943e40dbb78cee115bbbe89dc17f07b7a0f # v2.1.3
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+      env:
+        TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
       with:
         docker_image: "${{ env.DOCKER_SLUG }}:latest"
         dockerfile_path: "Dockerfile"


### PR DESCRIPTION
# Summary
Update the Docker scan actions to use a self-hosted Trivy vulnerability database. This is being done to address the rate limiting of the publicly hosted database.

# Related
- https://github.com/cds-snc/platform-core-services/issues/597