### PR TITLE
fix Vpn and gh secrets

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,8 +8,7 @@ env:
   AWS_REGION: ca-central-1
   DOCKER_ORG: public.ecr.aws/cds-snc
   DOCKER_SLUG: public.ecr.aws/cds-snc/notify-documentation
-  WORKFLOW_PAT: ${{ secrets.WORKFLOW_GITHUB_PAT }}
-  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}  
+  OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STAGING }}  
 
 permissions:
   id-token: write   # This is required for requesting the OIDC JWT
@@ -69,16 +68,23 @@ jobs:
         curl -o 1pass.deb https://downloads.1password.com/linux/debian/amd64/stable/1password-cli-amd64-latest.deb
         sudo dpkg -i 1pass.deb
 
-    - name: One Password Fetch
+    - name: Setup Terraform tools
+      uses: cds-snc/terraform-tools-setup@v1
+      env: # In case you want to override default versions
+        CONFTEST_VERSION: 0.30.0 
+        TERRAFORM_VERSION: 1.9.5
+        TERRAGRUNT_VERSION: 0.66.9
+        TF_SUMMARIZE_VERSION: 0.2.3                           
+
+    - name: Fetch VPN
       run: |
-        op read op://4eyyuwddp6w4vxlabrr2i2duxm/"Staging Github Actions VPN"/notesPlain > /var/tmp/staging.ovpn
+        curl https://raw.githubusercontent.com/cds-snc/notification-manifests/refs/heads/main/scripts/createVPNConfig.sh | bash -s staging
 
     - name: Connect to VPN
       uses: "kota65535/github-openvpn-connect-action@cd2ed8a90cc7b060dc4e001143e811b5f7ea0af5"
       with:
         config_file: /var/tmp/staging.ovpn
-        client_key: ${{ secrets.STAGING_OVPN_CLIENT_KEY }}
-        echo_config: false       
+        echo_config: false
         
     - name: Get Kubernetes configuration
       run: |


### PR DESCRIPTION
# Summary | Résumé

Convert VPN to autofetch config

Convert to github secrets to ones managed by TF

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/299

# Test instructions | Instructions pour tester la modification

Docker build and push runs

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [x] This PR does not break existing functionality.
- [x] This PR does not violate GCNotify's privacy policies.
- [x] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [x] This PR does not significantly alter performance.
- [x] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
