### PR TITLE
Fixed unclosed bolding asterisks

### DIFF
--- a/src/en/callbacks.md
+++ b/src/en/callbacks.md
@@ -62,7 +62,7 @@ GC Notify continues trying to deliver until a callback fails 25 times in 5 minut
 
 ::: warning Temporary suspensions
 
-If GC Notify has **frequent** problems delivering callbacks to your API, we may **temporarily suspend callback deliveries for your service and send you an email with steps to resolve the suspension.
+If GC Notify has **frequent** problems delivering callbacks to your API, we may **temporarily** suspend callback deliveries for your service and send you an email with steps to resolve the suspension.
 
 :::
 


### PR DESCRIPTION
# Summary | Résumé

This small PR fixes an unclosed bolding asterisk that was missed in https://github.com/cds-snc/notification-documentation/pull/162

## Related Issues | Cartes liées

# Test instructions | Instructions pour tester la modification

![image](https://github.com/user-attachments/assets/50f51e7e-6028-4b8b-8e4a-0b1c28ba859a)

Should be:

![image](https://github.com/user-attachments/assets/793d1148-c9e3-4c94-af7c-c87e17b2b585)


# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
