### PR TITLE
task: add care taker message

### DIFF
--- a/src/en/README.md
+++ b/src/en/README.md
@@ -1,7 +1,7 @@
 # Integrate the API
 
 ::: warning Communicating during caretaker period
-Some communications are prohibited during a federal election. Check with your communications branch if you’re not sure you can send an announcement or other message. For more information, read [the Guidelines](https://www.canada.ca/en/privy-council/services/publications/guidelines-conduct-ministers-state-exempt-staff-public-servants-election.html).
+Some communications are prohibited during a federal election. Check with your communications branch if you’re not sure you can send an announcement or other message. For more information, read the [Guidelines](https://www.canada.ca/en/privy-council/services/publications/guidelines-conduct-ministers-state-exempt-staff-public-servants-election.html).
 :::
 
 This documentation is for developers who want to integrate the [GC Notify](https://notification.canada.ca/) application programming interface (API) with their department's web application or back office system. If you’re not a developer or to learn how to use GC Notify outside of the API, visit [Guidance](https://notification.canada.ca/guidance)

--- a/src/en/README.md
+++ b/src/en/README.md
@@ -1,5 +1,9 @@
 # Integrate the API
 
+::: warning Communicating during caretaker period
+Some communications are prohibited during a federal election. Check with your communications branch if you’re not sure you can send an announcement or other message. For more information, read [the Guidelines](https://www.canada.ca/en/privy-council/services/publications/guidelines-conduct-ministers-state-exempt-staff-public-servants-election.html).
+:::
+
 This documentation is for developers who want to integrate the [GC Notify](https://notification.canada.ca/) application programming interface (API) with their department's web application or back office system. If you’re not a developer or to learn how to use GC Notify outside of the API, visit [Guidance](https://notification.canada.ca/guidance)
 
 Integrating the GC Notify API allows you to send email or text messages automatically. You might do this if you have a system that tracks a business process, so that whenever there's a status change, your clients could receive a notification about the update.

--- a/src/fr/README.md
+++ b/src/fr/README.md
@@ -1,7 +1,7 @@
 # Intégrer l’API
 
 ::: warning Communications durant la période de transition
-Certaines communications sont interdites en période d’élection fédérale. Si vous n’avez pas la certitude de pouvoir envoyer une annonce ou un message, veuillez vous renseigner auprès de la direction des communications de votre organisme. Pour en savoir plus, consultez les [lignes directrices](https://www.canada.ca/en/privy-council/services/publications/guidelines-conduct-ministers-state-exempt-staff-public-servants-election.html).
+Certaines communications sont interdites en période d’élection fédérale. Si vous n’avez pas la certitude de pouvoir envoyer une annonce ou un message, veuillez vous renseigner auprès de la direction des communications de votre organisme. Pour en savoir plus, consultez les [lignes directrices](https://www.canada.ca/fr/conseil-prive/services/publications/lignes-directrices-regissant-conduite-ministres-etat-membres-personnel-exonere-fonctionnaires-periode-electorale.html).
 :::
 
 Cette documentation s’adresse aux développeurs et développeuses qui souhaitent intégrer l’interface de programmation d’application (API) de [Notification GC](https://notification.canada.ca/?lang=fr) à l’application Web ou au système administratif de leur ministère. Si vous n’êtes pas développeur ou développeuse ou si vous souhaitez apprendre à utiliser Notification GC en dehors de l’API, consultez [les guides de référence](https://notification.canada.ca/guides-reference).

--- a/src/fr/README.md
+++ b/src/fr/README.md
@@ -1,5 +1,9 @@
 # Intégrer l’API
 
+::: warning Communications durant la période de transition
+Certaines communications sont interdites en période d’élection fédérale. Si vous n’avez pas la certitude de pouvoir envoyer une annonce ou un message, veuillez vous renseigner auprès de la direction des communications de votre organisme. Pour en savoir plus, consultez les [lignes directrices](https://www.canada.ca/en/privy-council/services/publications/guidelines-conduct-ministers-state-exempt-staff-public-servants-election.html).
+:::
+
 Cette documentation s’adresse aux développeurs et développeuses qui souhaitent intégrer l’interface de programmation d’application (API) de [Notification GC](https://notification.canada.ca/?lang=fr) à l’application Web ou au système administratif de leur ministère. Si vous n’êtes pas développeur ou développeuse ou si vous souhaitez apprendre à utiliser Notification GC en dehors de l’API, consultez [les guides de référence](https://notification.canada.ca/guides-reference).
 
 L’intégration de l’API Notification GC vous permet d’envoyer automatiquement des courriels ou des messages texte. Vous pouvez le faire si vous disposez d’un système qui suit un processus opérationnel, de sorte qu’à chaque fois qu’il y a une modification d’état, vos clients peuvent recevoir une notification à propos de la mise à jour.


### PR DESCRIPTION
# Summary | Résumé

This PR adds the caretaker notice to the first page of the API documentation in both English and French.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1779

# Test instructions | Instructions pour tester la modification
- Visit the documentation site in English
   - [ ] Ensure the English caretaker notice is present
- Visit the documentation site in French
   - [ ] Ensure the French caretaker notice is present

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
