### PR TITLE
Remove incorrect  filtering details for the `/v2/notifications/{notification_id}` endpoint 

### DIFF
--- a/src/en/status.md
+++ b/src/en/status.md
@@ -43,13 +43,6 @@ The ID of the notification. You can find the notification ID in the response to 
 
 You can also find it by [signing in to GC Notify](https://notification.canada.ca/sign-in) and going to the __API integration__ page.
 
-You can filter the returned messages by including the following optional parameters in the URL:
-
-- `template_type`
-- `status`
-- `reference`
-- `older_than`
-
 ### Response
 
 If the request is successful, the response body is `json` and the status code is `200`:

--- a/src/fr/etat.md
+++ b/src/fr/etat.md
@@ -43,13 +43,6 @@ L’ID de la notification. Vous pouvez trouver l’ID de notification dans la r�
 
 Vous pouvez également le trouver en [vous connectant à Notification GC](https://notification.canada.ca/sign-in?lang=fr) et en accédant à la page __Integration API__.
 
-Vous pouvez filtrer les messages retournés en incluant les paramètres facultatifs suivants dans l’adresse URL :
-
-- `template_type`
-- `status`
-- `reference`
-- `older_than`
-
 ### Réponse
 
 Si la demande est acceptée, le corps de la réponse est `json` et le code d’état est `200` :


### PR DESCRIPTION
# Summary | Résumé

Remove the filtering options from the `/v2/notifications/{notification_id}` from the Get Message Status page, as this feature does not exist on this endpoint.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1468

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
