### PR TITLE
Add a warning section about malware scanning

### DIFF
--- a/src/en/send.md
+++ b/src/en/send.md
@@ -98,6 +98,11 @@ You can leave out this argument if your service only has one reply-to email addr
 
 To turn on this feature, [sign in to GC Notify](https://notification.canada.ca/sign-in) and go to the __Settings__ page.
 
+::: tip Malware scanning
+
+GC Notify scans file attachments for malware before they are sent. If malware is detected, you will receive an error message and the notification will not be sent.
+:::
+
 ### File types
 
 You can upload .pdf, .csv, .jpeg, .png, .odt, .txt, .rtf, as well as Microsoft Excel and Microsoft Word files. If you need to send other file types, [contact us](https://notification.canada.ca/contact).
@@ -128,11 +133,6 @@ Some email providers and security rules block attachments. For example, governme
 Before choosing a sending method, perform tests to check what works best for your use case. You can also [contact us](https://notification.canada.ca/contact).
 
 ### Upload your file
-
-::: warning Malware scanning
-
-GC Notify scans file attachments for malware before they are sent. If malware is detected, you will receive an error message and the notification will not be sent.
-:::
 
 To send files, pass a dictionary in the `personalisation` argument. Pass this dictionary to the placeholder key if it’s present in your template or use a name of your choice.
 

--- a/src/en/send.md
+++ b/src/en/send.md
@@ -4,7 +4,7 @@ You can use GC Notify to send emails and text messages. These might be in respon
 
 **What you'll need:**
 
-To send a message with GC Notify, you'll need to set up a template in the user interface. 
+To send a message with GC Notify, you'll need to set up a template in the user interface.
 
 To create a template:
 
@@ -74,7 +74,7 @@ You can leave out this argument if a template does not have any placeholder fiel
 ```
 You can leave out this argument if you do not have a reference.
 
-**email_reply_to_id (optional)** 
+**email_reply_to_id (optional)**
 
 `email_reply_to_id` is an email address specified by you to receive replies from your users.
 
@@ -123,11 +123,16 @@ In contrast, recipients can access attachments indefinitely, if permitted by the
 
 ### In some situations, there may be advantages to link mode
 
-Some email providers and security rules block attachments. For example, government departments may restrict attachments for internal communication.  
+Some email providers and security rules block attachments. For example, government departments may restrict attachments for internal communication.
 
 Before choosing a sending method, perform tests to check what works best for your use case. You can also [contact us](https://notification.canada.ca/contact).
 
 ### Upload your file
+
+::: warning Malware scanning
+
+GC Notify scans file attachments for malware before they are sent. If malware is detected, you will receive an error message and the notification will not be sent.
+:::
 
 To send files, pass a dictionary in the `personalisation` argument. Pass this dictionary to the placeholder key if it’s present in your template or use a name of your choice.
 
@@ -169,7 +174,7 @@ Below is an example of sending multiple files:
 
 **HTTP parameters**
 ```json
-"personalisation": {        
+"personalisation": {
   "application_file": {
     "file": "file as base64 encoded string",
     "filename": "your_custom_filename.txt",


### PR DESCRIPTION
# Summary | Résumé

This PR adds a warning section to inform users about malware scanning that occurs on attachments sent via the API.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1096

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
