### PR TITLE
switch slack webhook

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -97,4 +97,4 @@ jobs:
       if: ${{ failure() }}
       run: |
         json='{"text":"<!here> CI is failing in <https://github.com/cds-snc/notification-documentation/actions/runs/'${{ github.run_id }}'|notification-documentation> !"}'
-        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_NOTIFY_WEBHOOK }}
+        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -40,4 +40,4 @@ jobs:
         if: ${{ failure() }}
         run: |
           json='{"text":"<!here> CI is failing in <https://github.com/cds-snc/notification-documentation/actions/runs/'${{ github.run_id }}'|notification-documentation> !"}'
-          curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_NOTIFY_WEBHOOK }}
+          curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/s3-backup.yml
+++ b/.github/workflows/s3-backup.yml
@@ -36,4 +36,4 @@ jobs:
       if: ${{ failure() }}
       run: |
         json='{"text":"S3 backup failed in <https://github.com/${{ github.repository }}>!"}'
-        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_NOTIFY_WEBHOOK }}
+        curl -X POST -H 'Content-type: application/json' --data "$json"  ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
# Summary | Résumé

Fix the slack webhook to post to notify-dev not SRE slack channel.

## Related Issues | Cartes liées

adhoc

# Test instructions | Instructions pour tester la modification

Verify failures get posted to the correct notify-dev channel

# Release Instructions | Instructions pour le déploiement

This PR must be merged first
https://github.com/cds-snc/notification-terraform/pull/2059

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
