### PR TITLE
Add a check so that GA only sends data from prod

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -22,14 +22,17 @@ module.exports = {
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','GTM-KRKRZQV');
     `],
-    // Google Analytics 4
-    ['script', { async: true, src: 'https://www.googletagmanager.com/gtag/js?id=G-R04KFLQCVQ' }],
-    ['script', {}, `
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-R04KFLQCVQ', {anonymize_ip: true});
-    `],
+    // Google Analytics 4 - only for production domain
+    ...((publicUrl === 'https://documentation.notification.canada.ca' || 
+         publicUrl === 'https://documentation.notification.canada.ca/') ? [
+      ['script', { async: true, src: 'https://www.googletagmanager.com/gtag/js?id=G-R04KFLQCVQ' }],
+      ['script', {}, `
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-R04KFLQCVQ', {anonymize_ip: true});
+      `]
+    ] : []),
   ],
   title: "GC Notify | Notification GC",
   base: baseURL || null,


### PR DESCRIPTION
# Summary | Résumé

Add a check so that GA only sends data from prod. This seemed like the simplest way to do it.

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/2053

# Test instructions | Instructions pour tester la modification

1. open the review app
2. view page source
3. search for the string "G-R04KFLQCVQ" in the raw html
4. ensure it isn't there

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
