### PR TITLE
Revert "add a check so that GA only sends data from prod (#198)"

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -22,17 +22,14 @@ module.exports = {
       'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','GTM-KRKRZQV');
     `],
-    // Google Analytics 4 - only for production domain
-    ...((publicUrl === 'https://documentation.notification.canada.ca' || 
-         publicUrl === 'https://documentation.notification.canada.ca/') ? [
-      ['script', { async: true, src: 'https://www.googletagmanager.com/gtag/js?id=G-R04KFLQCVQ' }],
-      ['script', {}, `
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'G-R04KFLQCVQ', {anonymize_ip: true});
-      `]
-    ] : []),
+    // Google Analytics 4
+    ['script', { async: true, src: 'https://www.googletagmanager.com/gtag/js?id=G-R04KFLQCVQ' }],
+    ['script', {}, `
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-R04KFLQCVQ', {anonymize_ip: true});
+    `],
   ],
   title: "GC Notify | Notification GC",
   base: baseURL || null,


### PR DESCRIPTION
# Summary | Résumé

This reverts commit 102745727581975668cb58f91e45bfc200ac37bd.

The environment variable I was trying to use here was null. Let's remove this check - we can filter for prod only data in google analytics.
