### PR TITLE
Enhance focus indicators for better visibility and usability

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -39,13 +39,13 @@ body
    - Provide a :focus fallback for older browsers
 */
 :focus-visible
-  outline 2px solid #000
+  outline 2px solid #0535d2
   outline-offset 2px
   box-shadow none
 
 /* Fallback for browsers that don't support :focus-visible */
 :focus
-  outline 2px solid #000
+  outline 2px solid #0535d2
   outline-offset 2px
   box-shadow none
 
@@ -58,12 +58,12 @@ body
    API docs area (.swagger-container) so form fields and interactive controls
    have a larger 4px/4px focus ring. */
 .swagger-container :focus-visible
-  outline 4px solid #000
-  outline-offset 4px
-  box-shadow none
+  outline 4px solid #0535d2 !important
+  outline-offset 4px !important
+  box-shadow none !important
 
 .swagger-container :focus
-  outline 4px solid #000
+  outline 4px solid #0535d2
   outline-offset 4px
   box-shadow none
 

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -32,3 +32,41 @@ body
 
 .sidebar
     font-size: unset
+
+
+/* Accessibility: clear, high-contrast focus indicator for all focusable elements
+   - Prefer :focus-visible to avoid showing when elements are clicked with a mouse
+   - Provide a :focus fallback for older browsers
+*/
+:focus-visible
+  outline 2px solid #000
+  outline-offset 2px
+  box-shadow none
+
+/* Fallback for browsers that don't support :focus-visible */
+:focus
+  outline 2px solid #000
+  outline-offset 2px
+  box-shadow none
+
+/* Hide focus when an element is focused by mouse in browsers with :focus-visible support */
+:focus:not(:focus-visible)
+  outline none
+  box-shadow none
+
+/* API spec / Swagger content: make focus more prominent inside the generated
+   API docs area (.swagger-container) so form fields and interactive controls
+   have a larger 4px/4px focus ring. */
+.swagger-container :focus-visible
+  outline 4px solid #000
+  outline-offset 4px
+  box-shadow none
+
+.swagger-container :focus
+  outline 4px solid #000
+  outline-offset 4px
+  box-shadow none
+
+.swagger-container :focus:not(:focus-visible)
+  outline none
+  box-shadow none


### PR DESCRIPTION
# Summary | Résumé

This pull request improves accessibility by adding clear, high-contrast focus indicators for all focusable elements, with enhanced styling for API documentation areas. The changes ensure better keyboard navigation support and visual clarity for users relying on focus cues.

Accessibility improvements:

* Added global CSS rules in `src/.vuepress/styles/index.styl` to provide a distinct black 2px outline for all focusable elements using `:focus-visible`, with a fallback for browsers that don't support it, and removed outlines when elements are focused via mouse.
* Enhanced focus indicators specifically within `.swagger-container` (API spec/Swagger docs) by increasing the outline to 4px, making focus more prominent for form fields and interactive controls.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/2299

# Test instructions | Instructions pour tester la modification
- Ensure docs site has better focus indicators overall
- Ensure api specs on docs site has clear focus while tabbing

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
