### PR TITLE
Make focus styles more visible

### DIFF
--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -56,16 +56,24 @@ body
 
 /* API spec / Swagger content: make focus more prominent inside the generated
    API docs area (.swagger-container) so form fields and interactive controls
-   have a larger 4px/4px focus ring. */
-.swagger-container :focus-visible
-  outline 4px solid #0535d2 !important
-  outline-offset 4px !important
+   have a larger 2px/2px focus ring. */
+.swagger-container :focus-visible,
+.swagger-container a:focus-visible,
+.swagger-container .link:focus-visible,
+.swagger-container button:focus-visible,
+.swagger-container input:focus-visible
+  outline 2px solid #0535d2 !important
+  outline-offset 2px !important
   box-shadow none !important
 
-.swagger-container :focus
-  outline 4px solid #0535d2
-  outline-offset 4px
-  box-shadow none
+.swagger-container :focus,
+.swagger-container a:focus,
+.swagger-container .link:focus,
+.swagger-container button:focus,
+.swagger-container input:focus
+  outline 2px solid #0535d2 !important
+  outline-offset 2px !important
+  box-shadow none !important
 
 .swagger-container :focus:not(:focus-visible)
   outline none


### PR DESCRIPTION
# Summary | Résumé

This PR fixes the `:focus` style that I guess is used in some browsers. You can view the style using chrome devtools.

Prod:
<img width="856" height="327" alt="Screenshot 2025-09-08 at 3 35 19 PM" src="https://github.com/user-attachments/assets/c3430474-43fa-4b6a-ad99-5471607d477f" />

This PR:
<img width="784" height="339" alt="Screenshot 2025-09-08 at 3 35 07 PM" src="https://github.com/user-attachments/assets/be520101-38bd-4bd1-88cb-a2d6f4731514" />

## Related Issues | Cartes liées

https://github.com/cds-snc/notification-planning/issues/2292

# Test instructions | Instructions pour tester la modification

1. open the review app
2. visit the open api page
3. right click one of the links and inspect in dev tools
4. select the `:hov` style in dev tools
5. select the `:focus` style to view that

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
