### PR TITLE
Fix colour contrast issues on the Open API page

### DIFF
--- a/src/.vuepress/components/SwaggerUI.vue
+++ b/src/.vuepress/components/SwaggerUI.vue
@@ -129,6 +129,19 @@
       }
       
     ],
+    updateIntegerColor: () => {
+      if (typeof window !== 'undefined') {
+        // Find all span elements and check their style attributes
+        document.querySelectorAll('span').forEach(el => {
+          const style = el.getAttribute('style');
+          if (style && style.includes('rgb(211, 99, 99)')) {
+            // Replace the specific RGB color with the new RGB color
+            const updatedStyle = style.replace('rgb(211, 99, 99)', 'rgb(246, 115, 115)');
+            el.setAttribute('style', updatedStyle);
+          }
+        });
+      }
+    },
     translateUI: () => {
       if (typeof window !== 'undefined') {
         if (window.location.pathname.includes('/fr/')) {
@@ -141,6 +154,9 @@
           });
         }
 
+        // Update integer color to meet WCAG color contrast
+        Translate.updateIntegerColor();     
+        
         // Handle the ::after translation for French only
         let styleTag = document.getElementById(styleId);
         if (window.location.pathname.includes('/fr/')) {

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -82,3 +82,12 @@ button.authorize
   
 button.authorize svg
   fill #2d7d32 !important
+
+/* Improve color contrast for operation block summary method to meet WCAG AA accessibility standards */
+div.opblock-get span.opblock-summary-method
+  color #ffffff !important
+  background-color #1976d2 !important
+
+div.opblock-post span.opblock-summary-method
+  color #ffffff !important
+  background-color #2d7d32 !important

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -71,104 +71,14 @@ body
   outline none
   box-shadow none
 
-/* Fix color contrast issues in Swagger UI for accessibility compliance */
+/* Improve color contrast for URL spans to meet WCAG AA accessibility standards */
+a span.url
+a
+  color #2c5aa0 !important
 
-/* Fix light gray parameter descriptions - improve from #6b6b6b to darker color */
-.swagger-ui .parameter__name,
-.swagger-ui .parameter__type,
-.swagger-ui .parameter__deprecated,
-.swagger-ui .parameter__in,
-.swagger-ui .parameter__extension,
-.swagger-ui .parameter__required,
-.swagger-ui .parameter__description,
-.swagger-ui .prop-type
-  color #333333 !important
-
-/* Fix response status code contrast */
-.swagger-ui .response-col_status
-  color #000000 !important
-  font-weight bold !important
-
-/* Improve contrast for response descriptions and schema information */
-.swagger-ui .response-col_description,
-.swagger-ui .renderedMarkdown p,
-.swagger-ui .model-box .model-title,
-.swagger-ui .model .description,
-.swagger-ui .prop-format,
-.swagger-ui .prop-enum
-  color #2c3e50 !important
-
-/* Fix table header contrast */
-.swagger-ui table thead tr th,
-.swagger-ui table thead tr td,
-.swagger-ui .col_header
-  background-color #f8f9fa !important
-  color #000000 !important
-  font-weight bold !important
-  border-color #333333 !important
-
-/* Improve border visibility for tables */
-.swagger-ui table tbody tr td,
-.swagger-ui .parameters-col_description,
-.swagger-ui .parameters-col_name
-  border-color #666666 !important
-
-/* Fix low contrast links and operation summaries */
-.swagger-ui .opblock-summary-description,
-.swagger-ui .opblock-description,
-.swagger-ui .opblock .opblock-summary-operation-id,
-.swagger-ui .opblock .opblock-summary-path,
-.swagger-ui .tab li
-  color #005ea5 !important
-
-/* Improve contrast for form inputs and placeholders */
-.swagger-ui .parameters input[type="text"],
-.swagger-ui .parameters input[type="password"],
-.swagger-ui .parameters select,
-.swagger-ui .parameters textarea
-  color #000000 !important
-  border-color #666666 !important
-
-.swagger-ui .parameters input::placeholder,
-.swagger-ui .parameters textarea::placeholder
-  color #666666 !important
-
-/* Fix contrast for disabled states */
-.swagger-ui .btn:disabled,
-.swagger-ui .btn[disabled]
-  color #666666 !important
-  background-color #f5f5f5 !important
-  border-color #cccccc !important
-
-/* Improve visibility of required parameter indicators */
-.swagger-ui .parameter__name.required:after,
-.swagger-ui .parameter__name.required span:after
-  color #d73502 !important
-  font-weight bold !important
-
-/* Fix JSON syntax highlighting for better contrast */
-.swagger-ui .highlight-code .hljs-string
-  color #008000 !important
-
-.swagger-ui .highlight-code .hljs-number
-  color #0066cc !important
-
-.swagger-ui .highlight-code .hljs-literal
-  color #d73502 !important
-
-/* Improve contrast for expandable sections and model properties */
-.swagger-ui .model-toggle,
-.swagger-ui .model-hint,
-.swagger-ui .prop-name,
-.swagger-ui .prop-type
-  color #333333 !important
-
-/* Fix authorization button contrast */
-.swagger-ui .btn.authorize
-  background-color #005ea5 !important
-  color #ffffff !important
-  border-color #005ea5 !important
-
-.swagger-ui .btn.authorize:hover
-  background-color #003d75 !important
-  border-color #003d75 !important
+/* Improve color contrast for authorize button to meet WCAG AA accessibility standards */
+button.authorize
+  color #2d7d32 !important
+  
+button.authorize svg
+  fill #2d7d32 !important

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -70,3 +70,105 @@ body
 .swagger-container :focus:not(:focus-visible)
   outline none
   box-shadow none
+
+/* Fix color contrast issues in Swagger UI for accessibility compliance */
+
+/* Fix light gray parameter descriptions - improve from #6b6b6b to darker color */
+.swagger-ui .parameter__name,
+.swagger-ui .parameter__type,
+.swagger-ui .parameter__deprecated,
+.swagger-ui .parameter__in,
+.swagger-ui .parameter__extension,
+.swagger-ui .parameter__required,
+.swagger-ui .parameter__description,
+.swagger-ui .prop-type
+  color #333333 !important
+
+/* Fix response status code contrast */
+.swagger-ui .response-col_status
+  color #000000 !important
+  font-weight bold !important
+
+/* Improve contrast for response descriptions and schema information */
+.swagger-ui .response-col_description,
+.swagger-ui .renderedMarkdown p,
+.swagger-ui .model-box .model-title,
+.swagger-ui .model .description,
+.swagger-ui .prop-format,
+.swagger-ui .prop-enum
+  color #2c3e50 !important
+
+/* Fix table header contrast */
+.swagger-ui table thead tr th,
+.swagger-ui table thead tr td,
+.swagger-ui .col_header
+  background-color #f8f9fa !important
+  color #000000 !important
+  font-weight bold !important
+  border-color #333333 !important
+
+/* Improve border visibility for tables */
+.swagger-ui table tbody tr td,
+.swagger-ui .parameters-col_description,
+.swagger-ui .parameters-col_name
+  border-color #666666 !important
+
+/* Fix low contrast links and operation summaries */
+.swagger-ui .opblock-summary-description,
+.swagger-ui .opblock-description,
+.swagger-ui .opblock .opblock-summary-operation-id,
+.swagger-ui .opblock .opblock-summary-path,
+.swagger-ui .tab li
+  color #005ea5 !important
+
+/* Improve contrast for form inputs and placeholders */
+.swagger-ui .parameters input[type="text"],
+.swagger-ui .parameters input[type="password"],
+.swagger-ui .parameters select,
+.swagger-ui .parameters textarea
+  color #000000 !important
+  border-color #666666 !important
+
+.swagger-ui .parameters input::placeholder,
+.swagger-ui .parameters textarea::placeholder
+  color #666666 !important
+
+/* Fix contrast for disabled states */
+.swagger-ui .btn:disabled,
+.swagger-ui .btn[disabled]
+  color #666666 !important
+  background-color #f5f5f5 !important
+  border-color #cccccc !important
+
+/* Improve visibility of required parameter indicators */
+.swagger-ui .parameter__name.required:after,
+.swagger-ui .parameter__name.required span:after
+  color #d73502 !important
+  font-weight bold !important
+
+/* Fix JSON syntax highlighting for better contrast */
+.swagger-ui .highlight-code .hljs-string
+  color #008000 !important
+
+.swagger-ui .highlight-code .hljs-number
+  color #0066cc !important
+
+.swagger-ui .highlight-code .hljs-literal
+  color #d73502 !important
+
+/* Improve contrast for expandable sections and model properties */
+.swagger-ui .model-toggle,
+.swagger-ui .model-hint,
+.swagger-ui .prop-name,
+.swagger-ui .prop-type
+  color #333333 !important
+
+/* Fix authorization button contrast */
+.swagger-ui .btn.authorize
+  background-color #005ea5 !important
+  color #ffffff !important
+  border-color #005ea5 !important
+
+.swagger-ui .btn.authorize:hover
+  background-color #003d75 !important
+  border-color #003d75 !important

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -91,3 +91,7 @@ div.opblock-get span.opblock-summary-method
 div.opblock-post span.opblock-summary-method
   color #ffffff !important
   background-color #2d7d32 !important
+
+/* Improve color contrast for parameter indicators to meet WCAG AA accessibility standards */
+div.parameter__in
+  color #4a4a4a !important

--- a/src/en/apispec.md
+++ b/src/en/apispec.md
@@ -2,4 +2,4 @@
 title: Open API Specification
 ---
 
-<SwaggerUI url="http://localhost:6011/v2/openapi-en" />
+<SwaggerUI url="https://api.notification.canada.ca/v2/openapi-en" />

--- a/src/en/apispec.md
+++ b/src/en/apispec.md
@@ -2,4 +2,4 @@
 title: Open API Specification
 ---
 
-<SwaggerUI url="https://api.notification.canada.ca/v2/openapi-en" />
+<SwaggerUI url="http://localhost:6011/v2/openapi-en" />


### PR DESCRIPTION
# Summary | Résumé

Fix colour contrast issues on the Open API page. 

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/2304

# Test instructions | Instructions pour tester la modification

1. visit the review site
2. visit the open api docs page
3. open some of the elements on the page
4. run an accessibility checker like the axe browser extension to check for colour contrast issues
5. there should be no colour contrast issues besides the red code text

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
