### PR TITLE
Update edit link text to indicate it opens in a new tab

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -71,7 +71,7 @@ module.exports = {
         backToNotifyText: 'Back to GC Notify',
         backToGuidanceLink: 'https://notification.canada.ca/guidance',
         backToGuidanceText: 'Visit Guidance',
-        editLinkText: 'Edit this page on GitHub',
+        editLinkText: 'Edit this page on GitHub (opens in a new tab)',
         lastUpdated: 'Last updated',
         serviceWorker: {
           updatePopup: {
@@ -109,7 +109,7 @@ module.exports = {
         backToNotifyText: 'Retour à Notification GC',
         backToGuidanceLink: 'https://notification.canada.ca/guides-reference',
         backToGuidanceText: 'Guides de référence',
-        editLinkText: 'Modifier cette page sur GitHub',
+        editLinkText: 'Modifier cette page sur GitHub (ouvre dans un nouvel onglet)',
         lastUpdated: 'Dernière mise à jour ',
         serviceWorker: {
           updatePopup: {


### PR DESCRIPTION
# Summary | Résumé

This pull request makes a minor update to the `editLinkText` in both English and French language configurations. The change clarifies that the GitHub link will open in a new tab.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/2313

# Test instructions | Instructions pour tester la modification

- Open docs site
- Go to get started
- Zoom to 200%
- [ ] Ensure you can use the keyboard to focus on the 3rd code block
- [ ] Ensure you can scroll with arrow keys while focused on the code block

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
