### PR TITLE
Update documentation for the `v2/notifications` endpoint

### DIFF
--- a/src/en/apispec.md
+++ b/src/en/apispec.md
@@ -2,4 +2,5 @@
 title: Open API Specification
 ---
 
-<SwaggerUI url="https://api.notification.canada.ca/v2/openapi-en" />
+<!-- <SwaggerUI url="https://api.notification.canada.ca/v2/openapi-en" /> -->
+<SwaggerUI url="http://localhost:6011/v2/openapi-en" />

--- a/src/en/apispec.md
+++ b/src/en/apispec.md
@@ -2,5 +2,4 @@
 title: Open API Specification
 ---
 
-<!-- <SwaggerUI url="https://api.notification.canada.ca/v2/openapi-en" /> -->
-<SwaggerUI url="http://localhost:6011/v2/openapi-en" />
+<SwaggerUI url="https://api.notification.canada.ca/v2/openapi-en" />

--- a/src/en/status.md
+++ b/src/en/status.md
@@ -105,6 +105,7 @@ You can filter the returned messages by including the following optional argumen
 - `status`
 - `reference`
 - `older_than`
+- `include_jobs`
 
 ### Arguments
 
@@ -145,6 +146,14 @@ Input the ID of a notification into this argument. If you use this `older_than` 
 If you leave out this argument, the method returns the most recent 250 notifications.
 
 The client only returns notifications that are 7 days old or newer. If the notification specified in this argument is older than 7 days, the client returns an empty response.
+
+#### include_jobs (optional)
+
+If you set this argument to `true`, the response will include notifications that were sent as part of a job (bulk send). By default, job notifications are not included.
+
+```
+"include_jobs": "true"
+```
 
 ### Response
 

--- a/src/fr/etat.md
+++ b/src/fr/etat.md
@@ -148,7 +148,7 @@ Le client ne retourne que les notifications envoyées lors des 7 derniers jours.
 
 #### Inclure les tâches (facultatif)
 
-Si vous définissez l'argument `include_jobs` à `true`, la réponse inclura les notifications envoyées dans le cadre d'une tâche (envoi en lot). Par défaut, les notifications provenant de tâches ne sont pas incluses.
+Si la valeur de l'argument `include_jobs` est `true`, la réponse inclura les notifications envoyées dans le cadre d'une tâche (envoi par lot). Par défaut, les notifications provenant de tâches ne sont pas incluses.
 
 ```
 "include_jobs": "true"

--- a/src/fr/etat.md
+++ b/src/fr/etat.md
@@ -104,6 +104,7 @@ Vous pouvez filtrer les messages retournés en incluant les arguments facultatif
 - `status`
 - `reference`
 - `older_than`
+- `include_jobs`
 
 ### Arguments
 
@@ -144,6 +145,14 @@ Si vous spécifiez le filtre `older_than`, la méthode renvoie les 250 notificat
 Si vous ignorez cet argument, la méthode renvoie les 250 notifications les plus récentes.
 
 Le client ne retourne que les notifications envoyées lors des 7 derniers jours. Si la notification indiquée dans cet argument a été envoyée il y a plus de 7 jours, le client renvoie une réponse vide.
+
+#### Inclure les tâches (facultatif)
+
+Si vous définissez l'argument `include_jobs` à `true`, la réponse inclura les notifications envoyées dans le cadre d'une tâche (envoi en lot). Par défaut, les notifications provenant de tâches ne sont pas incluses.
+
+```
+"include_jobs": "true"
+```
 
 ### Réponse
 


### PR DESCRIPTION
# Summary | Résumé

Update documentation for the `v2/notifications` endpoint to include the include_jobs param

This originated from a support request: https://gcdigital.slack.com/archives/C03FA4DJCCU/p1778162621536439


# Test instructions | Instructions pour tester la modification

Make sure the changes look okay:

EN: https://cds-snc.github.io/notification-documentation/fix/update-notifications-doc/review-apps/08accc/en/status.html#get-the-status-of-multiple-messages

FR: https://cds-snc.github.io/notification-documentation/fix/update-notifications-doc/review-apps/08accc/fr/etat.html#obtenir-l-etat-de-plusieurs-messages

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.
